### PR TITLE
Fixed Pay Bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ base-salary=1000.00
 
 Every connected player receives the base salary when the in-world date changes
 at midnight. Payday detects the date change rather than requiring an exact
-midnight tick, so players are still paid when sleeping skips past midnight.
+midnight tick. It also listens for Rising World's night-skip event and checks
+again after sleepers wake, so sleeping through midnight cannot miss payday.
 Other plugins can access the API through the loaded plugin instance:
 
 ```java

--- a/src/com/example/risingworldstarter/RisingWorldStarter.java
+++ b/src/com/example/risingworldstarter/RisingWorldStarter.java
@@ -5,6 +5,7 @@ import net.risingworld.api.Server;
 import net.risingworld.api.Timer;
 import net.risingworld.api.events.EventMethod;
 import net.risingworld.api.events.Listener;
+import net.risingworld.api.events.general.SkipNightEvent;
 import net.risingworld.api.events.player.PlayerCommandEvent;
 import net.risingworld.api.events.player.PlayerChangePositionEvent;
 import net.risingworld.api.events.player.PlayerDisconnectEvent;
@@ -50,7 +51,8 @@ public final class RisingWorldStarter extends Plugin implements Listener {
         claims = new ClaimService(Path.of(getPath(), "claims.properties"));
         claimAdmins = new ClaimAdminService(Path.of(getPath(), "claim-admins.properties"));
         economySettings = EconomySettings.load(Path.of(getPath(), "economy.properties"));
-        lastSalaryDate = null;
+        net.risingworld.api.objects.Time currentTime = Server.getGameTime();
+        lastSalaryDate = new WorldDate(currentTime.getYear(), currentTime.getMonth(), currentTime.getDay());
         registerEventListener(this);
         worldClockTimer = new Timer(1f, 0f, -1, this::updateWorldClockLabels);
         worldClockTimer.start();
@@ -63,6 +65,7 @@ public final class RisingWorldStarter extends Plugin implements Listener {
             worldClockTimer.kill();
             worldClockTimer = null;
         }
+        lastSalaryDate = null;
         balanceLabels.clear();
         worldTimeLabels.clear();
         claimVisuals.clear();
@@ -93,6 +96,15 @@ public final class RisingWorldStarter extends Plugin implements Listener {
         claimVisuals.remove(event.getPlayer().getUID());
         visualModes.remove(event.getPlayer().getUID());
         visualHeights.remove(event.getPlayer().getUID());
+    }
+
+    @EventMethod
+    public void onSkipNight(SkipNightEvent event) {
+        if (!event.isCancelled()) {
+            // The event fires before the clock jumps. Check shortly afterwards so
+            // sleeping players have woken and the new world date is available.
+            executeDelayed(1f, this::updateWorldClockLabels);
+        }
     }
 
     @EventMethod
@@ -411,7 +423,6 @@ public final class RisingWorldStarter extends Plugin implements Listener {
         for (UILabel label : worldTimeLabels.values()) {
             updateWorldClockLabel(label, time);
         }
-        lastSalaryDate = null;
     }
 
     private void payDailySalaryWhenDateChanges(net.risingworld.api.objects.Time time) {
@@ -426,11 +437,16 @@ public final class RisingWorldStarter extends Plugin implements Listener {
 
         lastSalaryDate = currentDate;
         long salary = economySettings.baseSalary();
-        for (Player player : Server.getAllPlayers()) {
+        Player[] players = Server.getAllPlayers();
+        System.out.println("[RisingWorldStarter] Running daily payroll for " + players.length
+                + " connected player(s) on " + currentDate);
+        for (Player player : players) {
             economy.createAccount(player.getUID(), economySettings.defaultBalance());
-            economy.deposit(player.getUID(), salary);
+            long newBalance = economy.deposit(player.getUID(), salary);
             updateBalanceLabel(player);
             player.sendTextMessage("<color=#77FF99>Daily salary paid:</color> " + formatBalance(salary));
+            System.out.println("[RisingWorldStarter] Paid " + player.getName() + " " + formatBalance(salary)
+                    + "; new balance " + formatBalance(newBalance));
         }
     }
 


### PR DESCRIPTION
This pull request improves the reliability and transparency of the daily salary (payday) feature, especially when players sleep through midnight in Rising World. The changes ensure that all players receive their base salary even if the night is skipped, and provide better logging for payroll actions. The most important changes are:

**Payday reliability and event handling:**

* The plugin now listens for the `SkipNightEvent` and triggers a check for salary payment after sleepers wake, ensuring that sleeping through midnight does not cause players to miss their payday. (`RisingWorldStarter.java`) [[1]](diffhunk://#diff-01fd5bd1605791168867ecdaf93cfd5ab23c6e0f39a16297a511da772556d476R8) [[2]](diffhunk://#diff-01fd5bd1605791168867ecdaf93cfd5ab23c6e0f39a16297a511da772556d476R101-R109) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L75-R76)

* The logic for tracking the last salary date is improved: it is initialized to the current in-game date on plugin enable and reset on disable, preventing missed or duplicate payments after reloads. (`RisingWorldStarter.java`) [[1]](diffhunk://#diff-01fd5bd1605791168867ecdaf93cfd5ab23c6e0f39a16297a511da772556d476L53-R55) [[2]](diffhunk://#diff-01fd5bd1605791168867ecdaf93cfd5ab23c6e0f39a16297a511da772556d476R68)

**Logging and transparency:**

* Added log statements to print the number of players paid and details of each payroll action, including new balances, to the server console for easier debugging and transparency. (`RisingWorldStarter.java`)

**Code cleanup:**

* Removed an unnecessary line that reset `lastSalaryDate` during world clock label updates, which could have interfered with salary logic. (`RisingWorldStarter.java`)