### PR TITLE
Added Clans

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ if (providers.gradleProperty('alternateBuildDir').present) {
 }
 
 group = 'com.example'
-version = '0.8.2'
+version = '0.8.3'
 
 def configuredRisingWorldPath = providers.gradleProperty('risingWorldPath')
         .orElse(providers.environmentVariable('RISING_WORLD_PATH'))

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: CivicCore
 main: com.example.risingworldstarter.CivicCore
-version: 0.8.2
+version: 0.8.3
 author: Adam Guthrie
 description: "Persistent economy and chunk-based land claims with in-world visualization"
 loadorder: 0

--- a/src/com/example/risingworldstarter/CivicCore.java
+++ b/src/com/example/risingworldstarter/CivicCore.java
@@ -8,6 +8,7 @@ import com.example.risingworldstarter.claims.ClaimAdminService;
 import com.example.risingworldstarter.claims.ClaimedChunk;
 import com.example.risingworldstarter.claims.ClaimService;
 import com.example.risingworldstarter.commands.CommandAction;
+import com.example.risingworldstarter.commands.CommandHelp;
 import com.example.risingworldstarter.commands.CommandRegistry;
 import com.example.risingworldstarter.commands.RegisteredCommand;
 import com.example.risingworldstarter.database.Database;
@@ -15,6 +16,10 @@ import com.example.risingworldstarter.database.SqliteDatabase;
 import com.example.risingworldstarter.economy.DatabaseEconomyService;
 import com.example.risingworldstarter.economy.EconomyApi;
 import com.example.risingworldstarter.economy.EconomySettings;
+import com.example.risingworldstarter.groups.Group;
+import com.example.risingworldstarter.groups.GroupMember;
+import com.example.risingworldstarter.groups.GroupRole;
+import com.example.risingworldstarter.groups.GroupService;
 import net.risingworld.api.Plugin;
 import net.risingworld.api.Server;
 import net.risingworld.api.Timer;
@@ -121,6 +126,7 @@ public final class CivicCore extends Plugin implements Listener {
     private ClaimService claims;
     private ClaimAdminService claimAdmins;
     private ChestService chests;
+    private GroupService groups;
     private EconomySettings economySettings;
     private StoreCatalog storeCatalog;
     private Path marketplaceConfigPath;
@@ -157,7 +163,9 @@ public final class CivicCore extends Plugin implements Listener {
         claims = new ClaimService(database);
         claimAdmins = new ClaimAdminService(database);
         chests = new ChestService(database);
+        groups = new GroupService(database);
         characterService = new CharacterService(database);
+        groups.migrateLegacy(worldDataPath.resolve("groups.properties"));
         if (LegacyStateMigrator.migrate(database, worldDataPath, databaseEconomy,
                 claims, claimAdmins, chests, characterService)) {
             debug("Migrated legacy mutable state into civiccore.db; original files retained as backups");
@@ -228,6 +236,10 @@ public final class CivicCore extends Plugin implements Listener {
                     worldDataPath.resolve("marketplace.json"));
             copyLegacyFile(olderWorldDataPath.resolve("marketplace.json"),
                     worldDataPath.resolve("marketplace.json"));
+            copyLegacyFile(previousWorldDataPath.resolve("groups.properties"),
+                    worldDataPath.resolve("groups.properties"));
+            copyLegacyFile(olderWorldDataPath.resolve("groups.properties"),
+                    worldDataPath.resolve("groups.properties"));
             copyLegacyFile(pluginPath.resolve("economy.properties"),
                     worldDataPath.resolve("economy.properties"));
             copyLegacyFile(pluginPath.resolve("marketplace.json"),
@@ -238,16 +250,19 @@ public final class CivicCore extends Plugin implements Listener {
                         || Files.exists(previousWorldDataPath.resolve("claims.properties"))
                         || Files.exists(previousWorldDataPath.resolve("claim-admins.properties"))
                         || Files.exists(previousWorldDataPath.resolve("chests.properties"))
+                        || Files.exists(previousWorldDataPath.resolve("groups.properties"))
                         || Files.isDirectory(previousWorldDataPath.resolve("characters"));
                 boolean hasOlderWorldData = Files.exists(olderWorldDataPath.resolve("balances.properties"))
                         || Files.exists(olderWorldDataPath.resolve("claims.properties"))
                         || Files.exists(olderWorldDataPath.resolve("claim-admins.properties"))
                         || Files.exists(olderWorldDataPath.resolve("chests.properties"))
+                        || Files.exists(olderWorldDataPath.resolve("groups.properties"))
                         || Files.isDirectory(olderWorldDataPath.resolve("characters"));
                 boolean hasFilesInWorldRoot = Files.exists(worldFolder.resolve("balances.properties"))
                         || Files.exists(worldFolder.resolve("claims.properties"))
                         || Files.exists(worldFolder.resolve("claim-admins.properties"))
                         || Files.exists(worldFolder.resolve("chests.properties"))
+                        || Files.exists(worldFolder.resolve("groups.properties"))
                         || Files.isDirectory(worldFolder.resolve("characters"));
                 Path legacySource = hasPreviousWorldData ? previousWorldDataPath
                         : hasOlderWorldData ? olderWorldDataPath
@@ -264,6 +279,8 @@ public final class CivicCore extends Plugin implements Listener {
                         worldDataPath.resolve("claim-admins.properties"));
                     copyLegacyFile(legacySource.resolve("chests.properties"),
                         worldDataPath.resolve("chests.properties"));
+                    copyLegacyFile(legacySource.resolve("groups.properties"),
+                        worldDataPath.resolve("groups.properties"));
                     copyLegacyDirectory(legacySource.resolve("characters"),
                         worldDataPath.resolve("characters"));
                     if (!hasPreviousWorldData && !hasFilesInWorldRoot) {
@@ -363,6 +380,12 @@ public final class CivicCore extends Plugin implements Listener {
             throw new IllegalStateException("Claims are not available before the plugin is enabled");
         }
         return claims;
+    }
+
+    /** Returns the world-scoped clan service for integrations with other plugins. */
+    public GroupService getGroupService() {
+        if (groups == null) throw new IllegalStateException("Clans are not available before the plugin is enabled");
+        return groups;
     }
 
     /** Returns the shared registry so other plugins can register commands and actions. */
@@ -550,7 +573,7 @@ public final class CivicCore extends Plugin implements Listener {
                 event.getChunkPositionY(), event.getChunkPositionZ());
         if (ownership == null || !ownership.locked()) return;
         String identity = activeClaimIdentity(event.getPlayer());
-        if (ownership.ownerUid().equals(identity)
+        if (canAccessOwner(identity, ownership.ownerUid())
                 || (isClaimAdmin(event.getPlayer()) && claimAdminOverrideEnabled)) return;
         event.setCancelled(true);
         event.getPlayer().sendTextMessage("<color=#FF7777>This chest is locked by "
@@ -701,7 +724,7 @@ public final class CivicCore extends Plugin implements Listener {
             return;
         }
         String activeClaimIdentity = activeClaimIdentity(player);
-        boolean isOwner = claim.ownerUid().equals(activeClaimIdentity);
+        boolean isOwner = canAccessOwner(activeClaimIdentity, claim.ownerUid());
         if (isOwner || (isClaimAdmin(player) && claimAdminOverrideEnabled)) return;
 
         event.setCancelled(true);
@@ -755,7 +778,7 @@ public final class CivicCore extends Plugin implements Listener {
 
     @EventMethod
     public void onPlayerCommand(PlayerCommandEvent event) {
-        String[] parts = event.getCommand().trim().split("\\s+", 3);
+        String[] parts = event.getCommand().trim().split("\\s+");
         RegisteredCommand command = commandRegistry.find(parts[0]);
         if (command == null) {
             return;
@@ -802,18 +825,36 @@ public final class CivicCore extends Plugin implements Listener {
                 List.of(), this::handleClaimAdminCommand);
         registerCommand("Storage", "/chest <lock|unlock|status>", "Manage the chest you are looking at.", true,
                 List.of(), this::handleChestCommand);
+        registerCommand("Groups", "/clan", "Show clan command usage.", true, List.of("/group"), List.of(
+                new CommandHelp("/clan create <name>", "Create a new clan."),
+                new CommandHelp("/clan info", "Show clan members, roles, and claims."),
+                new CommandHelp("/clan invite <character>", "Invite an online character."),
+                new CommandHelp("/clan accept", "Accept a pending clan invitation."),
+                new CommandHelp("/clan leave", "Leave your current clan."),
+                new CommandHelp("/clan kick <character>", "Remove a clan member."),
+                new CommandHelp("/clan promote <character>", "Promote a member to manager."),
+                new CommandHelp("/clan demote <character>", "Demote a manager to member."),
+                new CommandHelp("/clan claim", "Purchase the current chunk for the clan."),
+                new CommandHelp("/clan unclaim", "Release the current clan-owned chunk."),
+                new CommandHelp("/clan disband", "Disband the clan and release its claims.")), this::handleClanCommand);
     }
 
     private void registerCommand(String category, String usage, String description, boolean requiresCharacter,
                                  List<String> aliases, CommandAction action) {
+        registerCommand(category, usage, description, requiresCharacter, aliases, List.of(), action);
+    }
+
+    private void registerCommand(String category, String usage, String description, boolean requiresCharacter,
+                                 List<String> aliases, List<CommandHelp> additionalHelp, CommandAction action) {
         String primaryName = usage.split("\\s+", 2)[0];
         commandRegistry.register("CivicCore", primaryName, category, usage, description,
-                requiresCharacter, aliases, action);
+                requiresCharacter, aliases, additionalHelp, action);
     }
 
     private void showHelp(Player player) {
         player.sendTextMessage("<color=#E8C547>--- CivicCore Commands ---</color>");
-        for (RegisteredCommand command : commandRegistry.getCommands()) {
+        for (RegisteredCommand command : commandRegistry.getCommands().stream()
+                .filter(registered -> registered.category().equalsIgnoreCase("General")).toList()) {
             String aliases = command.aliases().isEmpty()
                     ? ""
                     : " <color=#888888>(aliases: " + String.join(", ", command.aliases()) + ")</color>";
@@ -878,26 +919,24 @@ public final class CivicCore extends Plugin implements Listener {
             y += 38f;
 
             for (RegisteredCommand command : category.getValue()) {
-                String commandText = command.usage();
-                if (!command.aliases().isEmpty()) {
-                    commandText += "  (" + String.join(", ", command.aliases()) + ")";
+                List<CommandHelp> rows = new ArrayList<>();
+                rows.add(new CommandHelp(command.usage(), command.description()));
+                rows.addAll(command.additionalHelp());
+                for (int rowIndex = 0; rowIndex < rows.size(); rowIndex++) {
+                    CommandHelp row = rows.get(rowIndex);
+                    String commandText = row.usage();
+                    if (rowIndex == 0 && !command.aliases().isEmpty())
+                        commandText += "  (" + String.join(", ", command.aliases()) + ")";
+                    UILabel usage = new UILabel(commandText);
+                    usage.setPosition(18f, y, false); usage.setSize(350f, 38f, false);
+                    usage.setFontSize(15f); usage.setFontColor((int) 0x77AAFFFFL);
+                    usage.setTextAlign(TextAnchor.MiddleLeft); commandList.addChild(usage);
+                    UILabel description = new UILabel(row.description());
+                    description.setPosition(376f, y, false); description.setSize(350f, 38f, false);
+                    description.setFontSize(15f); description.setFontColor((int) 0xDDDDDDFFL);
+                    description.setTextAlign(TextAnchor.MiddleLeft); commandList.addChild(description);
+                    y += 42f;
                 }
-                UILabel usage = new UILabel(commandText);
-                usage.setPosition(18f, y, false);
-                usage.setSize(350f, 38f, false);
-                usage.setFontSize(15f);
-                usage.setFontColor((int) 0x77AAFFFFL);
-                usage.setTextAlign(TextAnchor.MiddleLeft);
-                commandList.addChild(usage);
-
-                UILabel description = new UILabel(command.description());
-                description.setPosition(376f, y, false);
-                description.setSize(350f, 38f, false);
-                description.setFontSize(15f);
-                description.setFontColor((int) 0xDDDDDDFFL);
-                description.setTextAlign(TextAnchor.MiddleLeft);
-                commandList.addChild(description);
-                y += 42f;
             }
             y += 8f;
         }
@@ -927,7 +966,7 @@ public final class CivicCore extends Plugin implements Listener {
         if (previous != null) player.removeUIElement(previous.window());
 
         String version = getClass().getPackage().getImplementationVersion();
-        if (version == null || version.isBlank()) version = "0.8.2";
+        if (version == null || version.isBlank()) version = "0.8.3";
 
         UIElement window = new UIElement();
         window.setPosition(50f, 50f, true);
@@ -1029,7 +1068,7 @@ public final class CivicCore extends Plugin implements Listener {
                 player.sendTextMessage("<color=#FFAA66>This chest is not inside a claimed chunk.</color>");
                 return;
             }
-            boolean ownsChest = ownership.ownerUid().equals(activeClaimIdentity(player));
+            boolean ownsChest = canAccessOwner(activeClaimIdentity(player), ownership.ownerUid());
             boolean adminCanManage = isClaimAdmin(player) && claimAdminOverrideEnabled;
             if (!ownsChest && !adminCanManage) {
                 player.sendTextMessage("<color=#FF7777>This chest belongs to "
@@ -1047,6 +1086,120 @@ public final class CivicCore extends Plugin implements Listener {
                     object.getChunkPositionZ(), ownership, locked);
             player.sendTextMessage("<color=#77FF99>Chest " + (locked ? "locked" : "unlocked") + ".</color>");
         });
+    }
+
+    private void handleClanCommand(Player player, String[] parts) {
+        if (parts.length < 2) { sendClanUsage(player); return; }
+        String characterKey = characterKey(player);
+        String action = parts[1].toLowerCase(Locale.US);
+        try {
+            switch (action) {
+                case "create" -> {
+                    if (parts.length < 3) throw new IllegalArgumentException("Usage: /clan create <name>");
+                    Group group = groups.create(joinArguments(parts, 2), characterKey, player.getName());
+                    player.sendTextMessage("<color=#77FF99>Created clan " + group.name()
+                            + " and joined as Owner.</color>");
+                }
+                case "info", "members" -> showClanInfo(player, characterKey);
+                case "invite" -> {
+                    Player target = requireOnlineClanTarget(parts, 2);
+                    Group group = groups.findByMember(characterKey)
+                            .orElseThrow(() -> new IllegalStateException("You do not belong to a clan."));
+                    groups.invite(group.id(), characterKey, characterKey(target));
+                    player.sendTextMessage("<color=#77FF99>Invited " + target.getName() + " to " + group.name() + ".</color>");
+                    target.sendTextMessage("<color=#E8C547>" + player.getName() + " invited you to clan "
+                            + group.name() + ". Use /clan accept to join.</color>");
+                }
+                case "accept" -> {
+                    Group group = groups.acceptInvitation(characterKey, player.getName());
+                    player.sendTextMessage("<color=#77FF99>Joined clan " + group.name() + ".</color>");
+                }
+                case "leave" -> { groups.leave(characterKey); player.sendTextMessage("<color=#77FF99>You left your clan.</color>"); }
+                case "kick", "promote", "demote" -> {
+                    Player target = requireOnlineClanTarget(parts, 2);
+                    Group group = groups.findByMember(characterKey)
+                            .orElseThrow(() -> new IllegalStateException("You do not belong to a clan."));
+                    if (action.equals("kick")) groups.kick(group.id(), characterKey, characterKey(target));
+                    else groups.setManager(group.id(), characterKey, characterKey(target), action.equals("promote"));
+                    player.sendTextMessage("<color=#77FF99>Clan membership updated for " + target.getName() + ".</color>");
+                }
+                case "claim" -> claimCurrentChunkForClan(player, characterKey);
+                case "unclaim" -> unclaimCurrentChunkForClan(player, characterKey);
+                case "disband" -> {
+                    Group group = groups.findByMember(characterKey)
+                            .orElseThrow(() -> new IllegalStateException("You do not belong to a clan."));
+                    Group removed = groups.disband(group.id(), characterKey);
+                    int removedClaims = claims.deleteClaimsByOwner(removed.claimOwnerId());
+                    player.sendTextMessage("<color=#77FF99>Disbanded " + removed.name() + " and released "
+                            + removedClaims + " clan claim(s).</color>");
+                }
+                default -> sendClanUsage(player);
+            }
+        } catch (IllegalArgumentException | IllegalStateException exception) {
+            player.sendTextMessage("<color=#FF7777>" + exception.getMessage() + "</color>");
+        }
+        player.sendTextMessage("<color=#AAAAAA>Use </color><color=#77AAFF>/commands</color>"
+                + "<color=#AAAAAA> to browse every available command by category.</color>");
+    }
+
+    private void showClanInfo(Player player, String characterKey) {
+        Group group = groups.findByMember(characterKey)
+                .orElseThrow(() -> new IllegalStateException("You do not belong to a clan."));
+        player.sendTextMessage("<color=#E8C547>--- " + group.name() + " ---</color>");
+        for (GroupMember member : group.members().values().stream()
+                .sorted((left, right) -> left.role().compareTo(right.role())).toList()) {
+            player.sendTextMessage("- " + member.name() + " <color=#AAAAAA>[" + formatGroupRole(member.role()) + "]</color>");
+        }
+        player.sendTextMessage("<color=#AAAAAA>Clan claims: "
+                + claims.getClaimsByOwner(group.claimOwnerId()).size() + "</color>");
+    }
+
+    private void claimCurrentChunkForClan(Player player, String characterKey) {
+        Group group = groups.findByMember(characterKey)
+                .orElseThrow(() -> new IllegalStateException("You do not belong to a clan."));
+        if (!groups.canManage(group.id(), characterKey)) throw new IllegalStateException("Only a clan owner or manager can claim land.");
+        Vector3i chunk = player.getChunkPosition();
+        if (claims.getClaim(chunk.x, chunk.z).isPresent()) throw new IllegalStateException("This chunk is already claimed.");
+        if (!economy.withdraw(characterKey, economySettings.claimCost()))
+            throw new IllegalStateException("You need " + formatBalance(economySettings.claimCost()) + " to claim this chunk for the clan.");
+        if (!claims.claim(chunk.x, chunk.z, group.claimOwnerId(), group.name())) {
+            economy.deposit(characterKey, economySettings.claimCost());
+            throw new IllegalStateException("This chunk was claimed before the transaction completed.");
+        }
+        updateBalanceLabel(player);
+        player.sendTextMessage("<color=#77FF99>Claimed chunk " + chunk.x + ", " + chunk.z + " for " + group.name() + ".</color>");
+    }
+
+    private void unclaimCurrentChunkForClan(Player player, String characterKey) {
+        Group group = groups.findByMember(characterKey)
+                .orElseThrow(() -> new IllegalStateException("You do not belong to a clan."));
+        if (!groups.canManage(group.id(), characterKey)) throw new IllegalStateException("Only a clan owner or manager can release clan land.");
+        Vector3i chunk = player.getChunkPosition();
+        if (!claims.unclaim(chunk.x, chunk.z, group.claimOwnerId())) throw new IllegalStateException("This chunk is not owned by your clan.");
+        clearClaimVisuals(player);
+        player.sendTextMessage("<color=#77FF99>Released clan chunk " + chunk.x + ", " + chunk.z + ".</color>");
+    }
+
+    private Player requireOnlineClanTarget(String[] parts, int startIndex) {
+        if (parts.length <= startIndex) throw new IllegalArgumentException("Specify an online character name.");
+        Player target = Server.getPlayerByName(joinArguments(parts, startIndex));
+        if (target == null || !activeCharacters.containsKey(target.getUID()))
+            throw new IllegalArgumentException("That character must be online and active.");
+        return target;
+    }
+
+    private static String joinArguments(String[] parts, int startIndex) {
+        return String.join(" ", java.util.Arrays.copyOfRange(parts, startIndex, parts.length));
+    }
+
+    private static String formatGroupRole(GroupRole role) {
+        String name = role.name().toLowerCase(Locale.US);
+        return Character.toUpperCase(name.charAt(0)) + name.substring(1);
+    }
+
+    private static void sendClanUsage(Player player) {
+        player.sendTextMessage("<color=#E8C547>Clan commands:</color> create, info, invite, accept, leave, "
+                + "kick, promote, demote, claim, unclaim, disband");
     }
 
     private ChestOwnership getOrAssignChest(long globalId, int chunkX, int chunkY, int chunkZ) {
@@ -1149,7 +1302,7 @@ public final class CivicCore extends Plugin implements Listener {
         Vector3i chunk = player.getChunkPosition();
         Claim existing = claims.getClaim(chunk.x, chunk.z).orElse(null);
         if (existing != null) {
-            String owner = existing.ownerUid().equals(characterKey(player)) ? "you" : existing.ownerName();
+            String owner = canAccessOwner(characterKey(player), existing.ownerUid()) ? "you or your clan" : existing.ownerName();
             player.sendTextMessage("<color=#FF7777>Chunk " + chunk.x + ", " + chunk.z
                     + " is already claimed by " + owner + ".</color>");
             showCurrentChunk(player, false);
@@ -1225,7 +1378,7 @@ public final class CivicCore extends Plugin implements Listener {
             visual = createChunkVisual(chunk.x, chunk.z, groundY,
                     0.15f, 0.85f, 0.30f, 0.12f,
                     0.25f, 1.0f, 0.40f, 0.95f);
-        } else if (claim.ownerUid().equals(characterKey(player))) {
+        } else if (canAccessOwner(characterKey(player), claim.ownerUid())) {
             visual = createChunkVisual(chunk.x, chunk.z, groundY,
                     0.15f, 0.45f, 1.0f, 0.12f,
                     0.30f, 0.65f, 1.0f, 0.95f);
@@ -1606,6 +1759,11 @@ public final class CivicCore extends Plugin implements Listener {
     }
 
     private void confirmDeleteCharacter(Player player, CharacterService.CharacterSummary character) {
+        Group membership = groups.findByMember(character.economyKey()).orElse(null);
+        if (membership != null && membership.members().get(character.economyKey()).role() == GroupRole.OWNER) {
+            player.sendTextMessage("<color=#FF7777>Disband the clan before deleting its owner character.</color>");
+            return;
+        }
         player.showMessageBox(MessageBoxButtons.Yes_No, "Delete character",
                 "Permanently delete " + character.name()
                         + "? Their inventory, balance, and claims will also be deleted.",
@@ -1614,6 +1772,7 @@ public final class CivicCore extends Plugin implements Listener {
                     try {
                         CharacterService.CharacterSummary active = activeCharacters.get(player.getUID());
                         characterService.deleteCharacter(player.getUID(), character);
+                        groups.removeDeletedCharacter(character.economyKey());
                         int removedClaims = claims.deleteClaimsByOwner(character.economyKey());
                         economy.deleteAccount(character.economyKey());
                         if (active != null && active.id().equals(character.id())) {
@@ -1680,6 +1839,11 @@ public final class CivicCore extends Plugin implements Listener {
         String identity = character.economyKey();
         activeClaimIdentities.put(player.getUID(), identity);
         return identity;
+    }
+
+    private boolean canAccessOwner(String characterIdentity, String ownerIdentity) {
+        return characterIdentity != null && (ownerIdentity.equals(characterIdentity)
+                || groups.canAccess(characterIdentity, ownerIdentity));
     }
 
     private void saveActiveCharacters() {

--- a/src/com/example/risingworldstarter/CivicCore.java
+++ b/src/com/example/risingworldstarter/CivicCore.java
@@ -82,6 +82,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Minimal entry point for a Rising World (Unity version) plugin.
  */
 public final class CivicCore extends Plugin implements Listener {
+    private static final int CLAIM_OVERVIEW_RADIUS = 10;
     private static final int[] SKIN_COLORS = {
             0xF1C27D, 0xE0AC69, 0xC68642, 0xA66A3F, 0x8D5524, 0x5C3317
     };
@@ -1288,42 +1289,66 @@ public final class CivicCore extends Plugin implements Listener {
             return;
         }
         if (ownedChunks.isEmpty()) {
-            clearClaimVisuals(player);
-            player.sendTextMessage("<color=#AAAAAA>You do not own any chunks.</color>");
-            return;
-        }
-
-        player.sendTextMessage("<color=#E8C547>Your claimed chunks (" + ownedChunks.size() + "):</color>");
-        StringBuilder line = new StringBuilder();
-        for (ClaimedChunk chunk : ownedChunks) {
-            String coordinate = "[" + chunk.x() + ", " + chunk.z() + "]";
-            if (!line.isEmpty() && line.length() + coordinate.length() + 2 > 90) {
-                player.sendTextMessage(line.toString());
-                line.setLength(0);
+            player.sendTextMessage("<color=#AAAAAA>You do not personally own any chunks.</color>");
+        } else {
+            player.sendTextMessage("<color=#E8C547>Your claimed chunks (" + ownedChunks.size() + "):</color>");
+            StringBuilder line = new StringBuilder();
+            for (ClaimedChunk chunk : ownedChunks) {
+                String coordinate = "[" + chunk.x() + ", " + chunk.z() + "]";
+                if (!line.isEmpty() && line.length() + coordinate.length() + 2 > 90) {
+                    player.sendTextMessage(line.toString());
+                    line.setLength(0);
+                }
+                if (!line.isEmpty()) line.append(", ");
+                line.append(coordinate);
             }
-            if (!line.isEmpty()) {
-                line.append(", ");
-            }
-            line.append(coordinate);
-        }
-        if (!line.isEmpty()) {
-            player.sendTextMessage(line.toString());
+            if (!line.isEmpty()) player.sendTextMessage(line.toString());
         }
 
         clearClaimVisuals(player);
+        Vector3i center = player.getChunkPosition();
+        int minimumX = center.x - CLAIM_OVERVIEW_RADIUS;
+        int maximumX = center.x + CLAIM_OVERVIEW_RADIUS;
+        int minimumZ = center.z - CLAIM_OVERVIEW_RADIUS;
+        int maximumZ = center.z + CLAIM_OVERVIEW_RADIUS;
+        Map<ClaimedChunk, Claim> nearbyClaims = claims.getClaimsInArea(
+                minimumX, maximumX, minimumZ, maximumZ);
+        String clanOwnerId = groups.findByMember(characterKey).map(Group::claimOwnerId).orElse(null);
         float groundY = player.getPosition().y - 0.15f;
-        List<Area3D> visuals = new ArrayList<>(ownedChunks.size());
-        for (ClaimedChunk chunk : ownedChunks) {
-            Area3D visual = createChunkVisual(chunk.x(), chunk.z(), groundY,
-                    0.15f, 0.45f, 1.0f, 0.12f,
-                    0.30f, 0.65f, 1.0f, 0.95f);
-            visuals.add(visual);
-            player.addGameObject(visual);
+        int sideLength = CLAIM_OVERVIEW_RADIUS * 2 + 1;
+        List<Area3D> visuals = new ArrayList<>(sideLength * sideLength);
+        for (int chunkX = minimumX; chunkX <= maximumX; chunkX++) {
+            for (int chunkZ = minimumZ; chunkZ <= maximumZ; chunkZ++) {
+                Claim claim = nearbyClaims.get(new ClaimedChunk(chunkX, chunkZ));
+                Area3D visual;
+                if (claim == null) {
+                    visual = createChunkVisual(chunkX, chunkZ, groundY,
+                            0.15f, 0.85f, 0.30f, 0.12f,
+                            0.25f, 1.0f, 0.40f, 0.95f);
+                } else if (claim.ownerUid().equals(characterKey)) {
+                    visual = createChunkVisual(chunkX, chunkZ, groundY,
+                            0.15f, 0.45f, 1.0f, 0.12f,
+                            0.30f, 0.65f, 1.0f, 0.95f);
+                } else if (claim.ownerUid().equals(clanOwnerId)) {
+                    visual = createChunkVisual(chunkX, chunkZ, groundY,
+                            1.0f, 0.50f, 0.08f, 0.12f,
+                            1.0f, 0.65f, 0.18f, 0.95f);
+                } else {
+                    visual = createChunkVisual(chunkX, chunkZ, groundY,
+                            1.0f, 0.15f, 0.15f, 0.12f,
+                            1.0f, 0.30f, 0.30f, 0.95f);
+                }
+                visuals.add(visual);
+                player.addGameObject(visual);
+            }
         }
         claimVisuals.put(player.getUID(), visuals);
         visualModes.put(player.getUID(), "claims");
         visualHeights.put(player.getUID(), groundY);
-        player.sendTextMessage("<color=#77AAFF>Showing all owned claim squares. Use /claims again to hide them.</color>");
+        player.sendTextMessage("<color=#77AAFF>Blue: yours</color> | <color=#77FF77>Green: available</color>"
+                + " | <color=#FF991F>Orange: your clan</color> | <color=#FF5555>Red: unavailable</color>");
+        player.sendTextMessage("<color=#AAAAAA>Showing a " + sideLength + "x" + sideLength
+                + " chunk area around you. Use /claims again to hide it.</color>");
     }
 
     private void claimCurrentChunk(Player player) {

--- a/src/com/example/risingworldstarter/CivicCore.java
+++ b/src/com/example/risingworldstarter/CivicCore.java
@@ -63,6 +63,8 @@ import net.risingworld.api.worldelements.Area3D;
 import net.risingworld.api.worldelements.GameObject;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -834,6 +836,9 @@ public final class CivicCore extends Plugin implements Listener {
                 new CommandHelp("/clan kick <character>", "Remove a clan member."),
                 new CommandHelp("/clan promote <character>", "Promote a member to manager."),
                 new CommandHelp("/clan demote <character>", "Demote a manager to member."),
+                new CommandHelp("/clan balance", "View the clan treasury."),
+                new CommandHelp("/clan deposit <amount>", "Deposit personal funds into the clan treasury."),
+                new CommandHelp("/clan withdraw <amount>", "Withdraw clan funds to your character."),
                 new CommandHelp("/clan claim", "Purchase the current chunk for the clan."),
                 new CommandHelp("/clan unclaim", "Release the current clan-owned chunk."),
                 new CommandHelp("/clan disband", "Disband the clan and release its claims.")), this::handleClanCommand);
@@ -1123,6 +1128,21 @@ public final class CivicCore extends Plugin implements Listener {
                     else groups.setManager(group.id(), characterKey, characterKey(target), action.equals("promote"));
                     player.sendTextMessage("<color=#77FF99>Clan membership updated for " + target.getName() + ".</color>");
                 }
+                case "balance" -> {
+                    Group group = requireManagedClan(characterKey);
+                    player.sendTextMessage("<color=#E8C547>" + group.name() + " treasury:</color> "
+                            + formatBalance(groups.getBalance(group.id(), characterKey)));
+                }
+                case "deposit", "withdraw" -> {
+                    if (parts.length != 3) throw new IllegalArgumentException("Usage: /clan " + action + " <amount>");
+                    Group group = requireManagedClan(characterKey);
+                    long amount = parseCurrencyAmount(parts[2]);
+                    long balance = action.equals("deposit")
+                            ? groups.deposit(group.id(), characterKey, amount)
+                            : groups.withdraw(group.id(), characterKey, amount);
+                    updateBalanceLabel(player);
+                    player.sendTextMessage("<color=#77FF99>Clan treasury balance: " + formatBalance(balance) + ".</color>");
+                }
                 case "claim" -> claimCurrentChunkForClan(player, characterKey);
                 case "unclaim" -> unclaimCurrentChunkForClan(player, characterKey);
                 case "disband" -> {
@@ -1152,6 +1172,14 @@ public final class CivicCore extends Plugin implements Listener {
         }
         player.sendTextMessage("<color=#AAAAAA>Clan claims: "
                 + claims.getClaimsByOwner(group.claimOwnerId()).size() + "</color>");
+    }
+
+    private Group requireManagedClan(String characterKey) {
+        Group group = groups.findByMember(characterKey)
+                .orElseThrow(() -> new IllegalStateException("You do not belong to a clan."));
+        if (!groups.canManage(group.id(), characterKey))
+            throw new IllegalStateException("Only a clan owner or manager can manage clan funds.");
+        return group;
     }
 
     private void claimCurrentChunkForClan(Player player, String characterKey) {
@@ -1199,7 +1227,7 @@ public final class CivicCore extends Plugin implements Listener {
 
     private static void sendClanUsage(Player player) {
         player.sendTextMessage("<color=#E8C547>Clan commands:</color> create, info, invite, accept, leave, "
-                + "kick, promote, demote, claim, unclaim, disband");
+                + "kick, promote, demote, balance, deposit, withdraw, claim, unclaim, disband");
     }
 
     private ChestOwnership getOrAssignChest(long globalId, int chunkX, int chunkY, int chunkZ) {
@@ -2491,6 +2519,17 @@ public final class CivicCore extends Plugin implements Listener {
     private static String formatBalance(long minorUnits) {
         NumberFormat currency = NumberFormat.getCurrencyInstance(Locale.US);
         return currency.format(minorUnits / 100.0);
+    }
+
+    private static long parseCurrencyAmount(String value) {
+        try {
+            long amount = new BigDecimal(value).movePointRight(2)
+                    .setScale(0, RoundingMode.UNNECESSARY).longValueExact();
+            if (amount <= 0) throw new IllegalArgumentException("Amount must be greater than zero.");
+            return amount;
+        } catch (ArithmeticException | NumberFormatException exception) {
+            throw new IllegalArgumentException("Enter a valid amount with no more than two decimal places.");
+        }
     }
 
     private record PayPeriod(int year, int month, int day, int period) {

--- a/src/com/example/risingworldstarter/claims/ClaimService.java
+++ b/src/com/example/risingworldstarter/claims/ClaimService.java
@@ -10,6 +10,8 @@ import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -36,6 +38,25 @@ public final class ClaimService {
                 try (ResultSet result = query.executeQuery()) { while (result.next()) chunks.add(new ClaimedChunk(result.getInt(1), result.getInt(2))); }
             }
             return List.copyOf(chunks);
+        });
+    }
+
+    /** Returns all claims inside an inclusive chunk-coordinate square in one query. */
+    public Map<ClaimedChunk, Claim> getClaimsInArea(int minimumX, int maximumX,
+                                                    int minimumZ, int maximumZ) {
+        return database.read(connection -> {
+            Map<ClaimedChunk, Claim> result = new LinkedHashMap<>();
+            try (PreparedStatement query = connection.prepareStatement(
+                    "SELECT chunk_x,chunk_z,owner_id,owner_name FROM claims "
+                            + "WHERE chunk_x BETWEEN ? AND ? AND chunk_z BETWEEN ? AND ?")) {
+                query.setInt(1, minimumX); query.setInt(2, maximumX);
+                query.setInt(3, minimumZ); query.setInt(4, maximumZ);
+                try (ResultSet rows = query.executeQuery()) {
+                    while (rows.next()) result.put(new ClaimedChunk(rows.getInt(1), rows.getInt(2)),
+                            new Claim(rows.getString(3), rows.getString(4)));
+                }
+            }
+            return Map.copyOf(result);
         });
     }
 

--- a/src/com/example/risingworldstarter/claims/README.md
+++ b/src/com/example/risingworldstarter/claims/README.md
@@ -19,14 +19,16 @@ database. Other plugins can access claims through `CivicCore.getClaimService()`.
 
 - `/claim` claims the current chunk.
 - `/chunk` reports and visualizes the current chunk and owner.
-- `/claims` lists and visualizes all chunks owned by the active character.
+- `/claims` lists personal claims and toggles a 21-by-21 chunk ownership overview
+  centered on the active character's current chunk.
 - `/unclaim` releases the current chunk.
 - `/claimadmin add <online-player>` adds a claim administrator.
 - `/claimadmin remove <online-player>` removes a claim administrator.
 - `/claimadmin list` lists claim administrators.
 
-Claim boundaries are green when unclaimed, blue when owned by the viewing
-character, and red when owned by another character.
+In the `/claims` overview, boundaries are green when available, blue when owned
+by the viewing character, orange when owned by that character's clan, and red
+when unavailable. The overview uses one bounded database query when opened.
 
 ## Protection rules
 

--- a/src/com/example/risingworldstarter/commands/CommandHelp.java
+++ b/src/com/example/risingworldstarter/commands/CommandHelp.java
@@ -1,0 +1,3 @@
+package com.example.risingworldstarter.commands;
+
+public record CommandHelp(String usage, String description) { }

--- a/src/com/example/risingworldstarter/commands/CommandRegistry.java
+++ b/src/com/example/risingworldstarter/commands/CommandRegistry.java
@@ -22,12 +22,20 @@ public final class CommandRegistry {
                                                     String usage, String description,
                                                     boolean requiresCharacter, List<String> aliases,
                                                     CommandAction action) {
+        return register(owner, name, category, usage, description, requiresCharacter, aliases, List.of(), action);
+    }
+
+    public synchronized RegisteredCommand register(String owner, String name, String category,
+                                                    String usage, String description,
+                                                    boolean requiresCharacter, List<String> aliases,
+                                                    List<CommandHelp> additionalHelp, CommandAction action) {
         String normalizedOwner = requireText(owner, "owner");
         String normalizedName = normalizeName(name);
         String normalizedCategory = requireText(category, "category");
         String normalizedUsage = requireText(usage, "usage");
         String normalizedDescription = requireText(description, "description");
         Objects.requireNonNull(aliases, "aliases");
+        Objects.requireNonNull(additionalHelp, "additionalHelp");
         Objects.requireNonNull(action, "action");
 
         List<String> normalizedAliases = aliases.stream().map(CommandRegistry::normalizeName).toList();
@@ -43,7 +51,7 @@ public final class CommandRegistry {
         }
 
         RegisteredCommand command = new RegisteredCommand(normalizedOwner, normalizedName, normalizedCategory,
-                normalizedUsage, normalizedDescription, requiresCharacter, normalizedAliases, action);
+                normalizedUsage, normalizedDescription, requiresCharacter, normalizedAliases, additionalHelp, action);
         commands.add(command);
         for (String registeredName : allNames) commandsByName.put(registeredName, command);
         return command;

--- a/src/com/example/risingworldstarter/commands/RegisteredCommand.java
+++ b/src/com/example/risingworldstarter/commands/RegisteredCommand.java
@@ -5,8 +5,10 @@ import java.util.List;
 /** Immutable description of a command registered with CivicCore. */
 public record RegisteredCommand(String owner, String name, String category, String usage, String description,
                                 boolean requiresCharacter, List<String> aliases,
+                                List<CommandHelp> additionalHelp,
                                 CommandAction action) {
     public RegisteredCommand {
         aliases = List.copyOf(aliases);
+        additionalHelp = List.copyOf(additionalHelp);
     }
 }

--- a/src/com/example/risingworldstarter/database/README.md
+++ b/src/com/example/risingworldstarter/database/README.md
@@ -11,6 +11,6 @@ The canonical table definitions are maintained in [`schema.sql`](schema.sql),
 which is packaged into the plugin and executed during database initialization.
 
 Database state includes balances, characters and inventory blobs, claims, claim
-administrators, and chest locks. Operator-managed
+administrators, chest locks, clans, memberships, roles, and invitations. Operator-managed
 configuration remains in `plugin.properties`, `economy.properties`, and
 `marketplace.json`.

--- a/src/com/example/risingworldstarter/database/schema.sql
+++ b/src/com/example/risingworldstarter/database/schema.sql
@@ -53,3 +53,22 @@ CREATE TABLE IF NOT EXISTS characters (
     clothes BLOB,
     UNIQUE (account_uid, slot)
 );
+
+CREATE TABLE IF NOT EXISTS groups (
+    group_id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE COLLATE NOCASE
+);
+
+CREATE TABLE IF NOT EXISTS group_members (
+    character_key TEXT PRIMARY KEY,
+    group_id TEXT NOT NULL REFERENCES groups (group_id) ON DELETE CASCADE,
+    character_name TEXT NOT NULL,
+    role TEXT NOT NULL CHECK (role IN ('OWNER', 'MANAGER', 'MEMBER'))
+);
+
+CREATE INDEX IF NOT EXISTS group_members_group_idx ON group_members (group_id);
+
+CREATE TABLE IF NOT EXISTS group_invitations (
+    character_key TEXT PRIMARY KEY,
+    group_id TEXT NOT NULL REFERENCES groups (group_id) ON DELETE CASCADE
+);

--- a/src/com/example/risingworldstarter/groups/Group.java
+++ b/src/com/example/risingworldstarter/groups/Group.java
@@ -1,0 +1,9 @@
+package com.example.risingworldstarter.groups;
+
+import java.util.Map;
+
+public record Group(String id, String name, Map<String, GroupMember> members) {
+    public Group { members = Map.copyOf(members); }
+
+    public String claimOwnerId() { return "group:" + id; }
+}

--- a/src/com/example/risingworldstarter/groups/GroupMember.java
+++ b/src/com/example/risingworldstarter/groups/GroupMember.java
@@ -1,0 +1,3 @@
+package com.example.risingworldstarter.groups;
+
+public record GroupMember(String characterKey, String name, GroupRole role) { }

--- a/src/com/example/risingworldstarter/groups/GroupRole.java
+++ b/src/com/example/risingworldstarter/groups/GroupRole.java
@@ -1,0 +1,3 @@
+package com.example.risingworldstarter.groups;
+
+public enum GroupRole { OWNER, MANAGER, MEMBER }

--- a/src/com/example/risingworldstarter/groups/GroupService.java
+++ b/src/com/example/risingworldstarter/groups/GroupService.java
@@ -45,6 +45,7 @@ public final class GroupService {
                 insert.setString(1, ownerKey); insert.setString(2, id); insert.setString(3, ownerName);
                 insert.executeUpdate();
             }
+            setBalance(connection, "group:" + id, 0L);
             return requireGroup(connection, id);
         });
     }
@@ -144,7 +145,11 @@ public final class GroupService {
             Group group = requireGroup(connection, groupId);
             if (requireMember(group, ownerKey).role() != GroupRole.OWNER)
                 throw new IllegalStateException("Only the clan owner can disband it.");
+            String groupAccount = group.claimOwnerId();
+            if (selectBalance(connection, groupAccount) != 0L)
+                throw new IllegalStateException("Withdraw all clan funds before disbanding it.");
             execute(connection, "DELETE FROM groups WHERE group_id=?", groupId);
+            execute(connection, "DELETE FROM balances WHERE account_id=?", groupAccount);
             return group;
         });
     }
@@ -153,6 +158,44 @@ public final class GroupService {
         return database.read(connection -> exists(connection,
                 "SELECT 1 FROM group_members WHERE group_id=? AND character_key=? AND role IN ('OWNER','MANAGER')",
                 groupId, characterKey));
+    }
+
+    /** Returns the clan treasury balance after verifying the actor is an owner or manager. */
+    public long getBalance(String groupId, String actorKey) {
+        return database.read(connection -> {
+            requireManagement(requireGroup(connection, groupId), actorKey);
+            return selectBalance(connection, "group:" + groupId);
+        });
+    }
+
+    /** Atomically moves funds from the actor's character account into the clan treasury. */
+    public long deposit(String groupId, String actorKey, long amount) {
+        requirePositiveAmount(amount);
+        return database.transaction(connection -> {
+            requireManagement(requireGroup(connection, groupId), actorKey);
+            long characterBalance = selectBalance(connection, actorKey);
+            if (characterBalance < amount) throw new IllegalStateException("You do not have enough funds.");
+            String groupAccount = "group:" + groupId;
+            long updatedGroupBalance = Math.addExact(selectBalance(connection, groupAccount), amount);
+            setBalance(connection, actorKey, characterBalance - amount);
+            setBalance(connection, groupAccount, updatedGroupBalance);
+            return updatedGroupBalance;
+        });
+    }
+
+    /** Atomically moves funds from the clan treasury into the actor's character account. */
+    public long withdraw(String groupId, String actorKey, long amount) {
+        requirePositiveAmount(amount);
+        return database.transaction(connection -> {
+            requireManagement(requireGroup(connection, groupId), actorKey);
+            String groupAccount = "group:" + groupId;
+            long groupBalance = selectBalance(connection, groupAccount);
+            if (groupBalance < amount) throw new IllegalStateException("The clan does not have enough funds.");
+            long updatedCharacterBalance = Math.addExact(selectBalance(connection, actorKey), amount);
+            setBalance(connection, groupAccount, groupBalance - amount);
+            setBalance(connection, actorKey, updatedCharacterBalance);
+            return groupBalance - amount;
+        });
     }
 
     public List<Group> getGroups() { return database.read(connection -> {
@@ -227,6 +270,9 @@ public final class GroupService {
     private static GroupMember requireManagement(Group group, String key) { GroupMember member = requireMember(group, key); if (member.role() == GroupRole.MEMBER) throw new IllegalStateException("A clan owner or manager is required."); return member; }
     private static boolean exists(Connection c, String sql, String... values) throws java.sql.SQLException { return selectString(c, sql, values).isPresent(); }
     private static Optional<String> selectString(Connection c, String sql, String... values) throws java.sql.SQLException { try (PreparedStatement q = c.prepareStatement(sql)) { for (int i=0;i<values.length;i++) q.setString(i+1, values[i]); try (ResultSet rows=q.executeQuery()) { return rows.next()?Optional.ofNullable(rows.getString(1)):Optional.empty(); } } }
+    private static long selectBalance(Connection connection, String accountId) throws java.sql.SQLException { try (PreparedStatement query=connection.prepareStatement("SELECT balance FROM balances WHERE account_id=?")) { query.setString(1,accountId); try(ResultSet row=query.executeQuery()){return row.next()?row.getLong(1):0L;} } }
+    private static void setBalance(Connection connection, String accountId, long amount) throws java.sql.SQLException { try (PreparedStatement statement=connection.prepareStatement("INSERT INTO balances(account_id,balance) VALUES(?,?) ON CONFLICT(account_id) DO UPDATE SET balance=excluded.balance")) { statement.setString(1,accountId); statement.setLong(2,amount); statement.executeUpdate(); } }
+    private static void requirePositiveAmount(long amount) { if(amount<=0)throw new IllegalArgumentException("Amount must be greater than zero."); }
     private static void execute(Connection c, String sql, String... values) throws java.sql.SQLException { try (PreparedStatement q=c.prepareStatement(sql)) { for(int i=0;i<values.length;i++)q.setString(i+1,values[i]); q.executeUpdate(); } }
     private static String decode(String value) { return new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8); }
     private static String requireText(String value, String field) { if(value==null||value.isBlank())throw new IllegalArgumentException(field+" cannot be blank"); String result=value.trim(); if(result.length()>32)throw new IllegalArgumentException(field+" cannot exceed 32 characters"); return result; }

--- a/src/com/example/risingworldstarter/groups/GroupService.java
+++ b/src/com/example/risingworldstarter/groups/GroupService.java
@@ -1,0 +1,233 @@
+package com.example.risingworldstarter.groups;
+
+import com.example.risingworldstarter.database.Database;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.UUID;
+
+/** Database-backed world-scoped clan membership and role service. */
+public final class GroupService {
+    private static final String MIGRATION_MARKER = "legacy_groups_migrated_v1";
+    private final Database database;
+
+    public GroupService(Database database) { this.database = database; }
+
+    public Group create(String name, String ownerKey, String ownerName) {
+        String normalizedName = requireText(name, "group name");
+        return database.transaction(connection -> {
+            if (findByMember(connection, ownerKey).isPresent())
+                throw new IllegalStateException("You already belong to a clan.");
+            String id = UUID.randomUUID().toString();
+            try (PreparedStatement insert = connection.prepareStatement(
+                    "INSERT INTO groups(group_id,name) VALUES(?,?)")) {
+                insert.setString(1, id); insert.setString(2, normalizedName);
+                try { insert.executeUpdate(); }
+                catch (java.sql.SQLException exception) {
+                    if (exception.getMessage().toLowerCase().contains("unique"))
+                        throw new IllegalStateException("A clan with that name already exists.");
+                    throw exception;
+                }
+            }
+            try (PreparedStatement insert = connection.prepareStatement(
+                    "INSERT INTO group_members(character_key,group_id,character_name,role) VALUES(?,?,?,'OWNER')")) {
+                insert.setString(1, ownerKey); insert.setString(2, id); insert.setString(3, ownerName);
+                insert.executeUpdate();
+            }
+            return requireGroup(connection, id);
+        });
+    }
+
+    public Optional<Group> get(String id) { return database.read(c -> findGroup(c, id)); }
+    public Optional<Group> findByMember(String key) { return database.read(c -> findByMember(c, key)); }
+
+    public boolean canAccess(String characterKey, String claimOwnerId) {
+        if (claimOwnerId == null || !claimOwnerId.startsWith("group:")) return false;
+        String id = claimOwnerId.substring("group:".length());
+        return database.read(connection -> exists(connection,
+                "SELECT 1 FROM group_members WHERE group_id=? AND character_key=?", id, characterKey));
+    }
+
+    public void invite(String groupId, String actorKey, String targetKey) {
+        database.write(connection -> {
+            Group group = requireGroup(connection, groupId); requireManagement(group, actorKey);
+            if (findByMember(connection, targetKey).isPresent())
+                throw new IllegalStateException("That character already belongs to a clan.");
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "INSERT INTO group_invitations(character_key,group_id) VALUES(?,?) "
+                            + "ON CONFLICT(character_key) DO UPDATE SET group_id=excluded.group_id")) {
+                statement.setString(1, targetKey); statement.setString(2, groupId); statement.executeUpdate();
+            }
+            return null;
+        });
+    }
+
+    public Group acceptInvitation(String characterKey, String characterName) {
+        return database.transaction(connection -> {
+            if (findByMember(connection, characterKey).isPresent())
+                throw new IllegalStateException("You already belong to a clan.");
+            String groupId = selectString(connection,
+                    "SELECT group_id FROM group_invitations WHERE character_key=?", characterKey)
+                    .orElseThrow(() -> new IllegalStateException("You do not have a pending clan invitation."));
+            try (PreparedStatement insert = connection.prepareStatement(
+                    "INSERT INTO group_members(character_key,group_id,character_name,role) VALUES(?,?,?,'MEMBER')")) {
+                insert.setString(1, characterKey); insert.setString(2, groupId); insert.setString(3, characterName);
+                insert.executeUpdate();
+            }
+            execute(connection, "DELETE FROM group_invitations WHERE character_key=?", characterKey);
+            return requireGroup(connection, groupId);
+        });
+    }
+
+    public void leave(String characterKey) {
+        database.write(connection -> {
+            Group group = requireMembership(connection, characterKey);
+            if (group.members().get(characterKey).role() == GroupRole.OWNER)
+                throw new IllegalStateException("The owner must disband the clan instead of leaving.");
+            execute(connection, "DELETE FROM group_members WHERE character_key=?", characterKey);
+            execute(connection, "DELETE FROM group_invitations WHERE character_key=?", characterKey);
+            return null;
+        });
+    }
+
+    public void removeDeletedCharacter(String characterKey) {
+        database.write(connection -> {
+            Optional<Group> membership = findByMember(connection, characterKey);
+            if (membership.isPresent() && membership.get().members().get(characterKey).role() == GroupRole.OWNER)
+                throw new IllegalStateException("Disband the clan before deleting its owner character.");
+            execute(connection, "DELETE FROM group_members WHERE character_key=?", characterKey);
+            execute(connection, "DELETE FROM group_invitations WHERE character_key=?", characterKey);
+            return null;
+        });
+    }
+
+    public void kick(String groupId, String actorKey, String targetKey) {
+        database.write(connection -> {
+            Group group = requireGroup(connection, groupId);
+            GroupMember actor = requireManagement(group, actorKey), target = requireMember(group, targetKey);
+            if (target.role() == GroupRole.OWNER || (target.role() == GroupRole.MANAGER && actor.role() != GroupRole.OWNER))
+                throw new IllegalStateException("Only the owner can remove a manager; the owner cannot be removed.");
+            execute(connection, "DELETE FROM group_members WHERE character_key=? AND group_id=?", targetKey, groupId);
+            return null;
+        });
+    }
+
+    public void setManager(String groupId, String ownerKey, String targetKey, boolean manager) {
+        database.write(connection -> {
+            Group group = requireGroup(connection, groupId);
+            if (requireMember(group, ownerKey).role() != GroupRole.OWNER)
+                throw new IllegalStateException("Only the clan owner can change managers.");
+            GroupMember target = requireMember(group, targetKey);
+            if (target.role() == GroupRole.OWNER) throw new IllegalStateException("The owner's role cannot be changed.");
+            try (PreparedStatement update = connection.prepareStatement(
+                    "UPDATE group_members SET role=? WHERE group_id=? AND character_key=?")) {
+                update.setString(1, manager ? "MANAGER" : "MEMBER"); update.setString(2, groupId);
+                update.setString(3, targetKey); update.executeUpdate();
+            }
+            return null;
+        });
+    }
+
+    public Group disband(String groupId, String ownerKey) {
+        return database.transaction(connection -> {
+            Group group = requireGroup(connection, groupId);
+            if (requireMember(group, ownerKey).role() != GroupRole.OWNER)
+                throw new IllegalStateException("Only the clan owner can disband it.");
+            execute(connection, "DELETE FROM groups WHERE group_id=?", groupId);
+            return group;
+        });
+    }
+
+    public boolean canManage(String groupId, String characterKey) {
+        return database.read(connection -> exists(connection,
+                "SELECT 1 FROM group_members WHERE group_id=? AND character_key=? AND role IN ('OWNER','MANAGER')",
+                groupId, characterKey));
+    }
+
+    public List<Group> getGroups() { return database.read(connection -> {
+        var result = new java.util.ArrayList<Group>();
+        try (PreparedStatement query = connection.prepareStatement("SELECT group_id FROM groups ORDER BY name");
+             ResultSet rows = query.executeQuery()) {
+            while (rows.next()) result.add(requireGroup(connection, rows.getString(1)));
+        }
+        return List.copyOf(result);
+    }); }
+
+    public void migrateLegacy(Path file) {
+        database.transaction(connection -> {
+            if (exists(connection, "SELECT 1 FROM metadata WHERE key=?", MIGRATION_MARKER)) return null;
+            if (Files.isRegularFile(file)) migrateProperties(connection, file);
+            try (PreparedStatement marker = connection.prepareStatement("INSERT INTO metadata(key,value) VALUES(?,CURRENT_TIMESTAMP)")) {
+                marker.setString(1, MIGRATION_MARKER); marker.executeUpdate();
+            }
+            return null;
+        });
+    }
+
+    private static void migrateProperties(Connection connection, Path file) throws java.sql.SQLException {
+        Properties values = new Properties();
+        try (InputStream input = Files.newInputStream(file)) { values.load(input); }
+        catch (java.io.IOException exception) { throw new IllegalStateException("Could not migrate clans from " + file, exception); }
+        for (String key : values.stringPropertyNames()) if (key.startsWith("group.") && key.endsWith(".name")) {
+            String id = key.substring(6, key.length() - 5);
+            try (PreparedStatement insert = connection.prepareStatement("INSERT INTO groups(group_id,name) VALUES(?,?) ON CONFLICT DO NOTHING")) {
+                insert.setString(1, id); insert.setString(2, decode(values.getProperty(key))); insert.executeUpdate();
+            }
+        }
+        for (String key : values.stringPropertyNames()) {
+            if (key.startsWith("group.") && key.contains(".member.")) {
+                int marker = key.indexOf(".member."); String id = key.substring(6, marker);
+                String characterKey = decode(key.substring(marker + 8)); String[] value = values.getProperty(key).split(":", 2);
+                if (value.length != 2) continue;
+                try (PreparedStatement insert = connection.prepareStatement("INSERT INTO group_members(character_key,group_id,character_name,role) VALUES(?,?,?,?) ON CONFLICT DO NOTHING")) {
+                    insert.setString(1, characterKey); insert.setString(2, id); insert.setString(3, decode(value[1]));
+                    insert.setString(4, GroupRole.valueOf(value[0]).name()); insert.executeUpdate();
+                }
+            } else if (key.startsWith("invite.")) {
+                try (PreparedStatement insert = connection.prepareStatement("INSERT INTO group_invitations(character_key,group_id) VALUES(?,?) ON CONFLICT DO NOTHING")) {
+                    insert.setString(1, decode(key.substring(7))); insert.setString(2, values.getProperty(key)); insert.executeUpdate();
+                }
+            }
+        }
+    }
+
+    private static Optional<Group> findByMember(Connection connection, String key) throws java.sql.SQLException {
+        Optional<String> id = selectString(connection, "SELECT group_id FROM group_members WHERE character_key=?", key);
+        return id.isEmpty() ? Optional.empty() : findGroup(connection, id.get());
+    }
+    private static Optional<Group> findGroup(Connection connection, String id) throws java.sql.SQLException {
+        try (PreparedStatement query = connection.prepareStatement("SELECT name FROM groups WHERE group_id=?")) {
+            query.setString(1, id); try (ResultSet row = query.executeQuery()) {
+                if (!row.next()) return Optional.empty(); String name = row.getString(1);
+                Map<String, GroupMember> members = new LinkedHashMap<>();
+                try (PreparedStatement memberQuery = connection.prepareStatement("SELECT character_key,character_name,role FROM group_members WHERE group_id=? ORDER BY role,character_name")) {
+                    memberQuery.setString(1, id); try (ResultSet memberRows = memberQuery.executeQuery()) {
+                        while (memberRows.next()) { String key = memberRows.getString(1);
+                            members.put(key, new GroupMember(key, memberRows.getString(2), GroupRole.valueOf(memberRows.getString(3)))); }
+                    }
+                }
+                return Optional.of(new Group(id, name, members));
+            }
+        }
+    }
+    private static Group requireMembership(Connection c, String key) throws java.sql.SQLException { return findByMember(c, key).orElseThrow(() -> new IllegalStateException("You do not belong to a clan.")); }
+    private static Group requireGroup(Connection c, String id) throws java.sql.SQLException { return findGroup(c, id).orElseThrow(() -> new IllegalStateException("Clan no longer exists.")); }
+    private static GroupMember requireMember(Group group, String key) { GroupMember member = group.members().get(key); if (member == null) throw new IllegalStateException("That character is not in your clan."); return member; }
+    private static GroupMember requireManagement(Group group, String key) { GroupMember member = requireMember(group, key); if (member.role() == GroupRole.MEMBER) throw new IllegalStateException("A clan owner or manager is required."); return member; }
+    private static boolean exists(Connection c, String sql, String... values) throws java.sql.SQLException { return selectString(c, sql, values).isPresent(); }
+    private static Optional<String> selectString(Connection c, String sql, String... values) throws java.sql.SQLException { try (PreparedStatement q = c.prepareStatement(sql)) { for (int i=0;i<values.length;i++) q.setString(i+1, values[i]); try (ResultSet rows=q.executeQuery()) { return rows.next()?Optional.ofNullable(rows.getString(1)):Optional.empty(); } } }
+    private static void execute(Connection c, String sql, String... values) throws java.sql.SQLException { try (PreparedStatement q=c.prepareStatement(sql)) { for(int i=0;i<values.length;i++)q.setString(i+1,values[i]); q.executeUpdate(); } }
+    private static String decode(String value) { return new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8); }
+    private static String requireText(String value, String field) { if(value==null||value.isBlank())throw new IllegalArgumentException(field+" cannot be blank"); String result=value.trim(); if(result.length()>32)throw new IllegalArgumentException(field+" cannot exceed 32 characters"); return result; }
+}

--- a/src/com/example/risingworldstarter/groups/README.md
+++ b/src/com/example/risingworldstarter/groups/README.md
@@ -10,4 +10,11 @@ ordinary members and manage clan land. All members can access clan-owned chunks,
 which use the stable claim owner identity `group:<group-id>`.
 
 Commands include `/clan create`, `info`, `invite`, `accept`, `leave`, `kick`,
-`promote`, `demote`, `claim`, `unclaim`, and `disband`. `/group` is an alias.
+`promote`, `demote`, `balance`, `deposit`, `withdraw`, `claim`, `unclaim`, and
+`disband`. `/group` is an alias.
+
+Each clan has a treasury account under its stable `group:<group-id>` identity.
+Owners and managers can view its balance, deposit funds from their active
+character account, and withdraw funds back to that account. Each transfer is a
+single database transaction. A funded clan must empty its treasury before it
+can be disbanded.

--- a/src/com/example/risingworldstarter/groups/README.md
+++ b/src/com/example/risingworldstarter/groups/README.md
@@ -1,0 +1,13 @@
+# Groups and clans
+
+Clans, roles, memberships, and invitations are stored in the world-scoped
+`civiccore.db`. The canonical tables are in
+[`../database/schema.sql`](../database/schema.sql). Existing
+`groups.properties` data is imported once and retained only as a legacy backup.
+
+Owners control the clan and appoint managers. Managers can invite or remove
+ordinary members and manage clan land. All members can access clan-owned chunks,
+which use the stable claim owner identity `group:<group-id>`.
+
+Commands include `/clan create`, `info`, `invite`, `accept`, `leave`, `kick`,
+`promote`, `demote`, `claim`, `unclaim`, and `disband`. `/group` is an alias.


### PR DESCRIPTION
This pull request updates the CivicCore plugin to version 0.8.3 and introduces several improvements, most notably adding support for group (clan) data migration and commands, enhancing legacy data migration to cover group data, and improving command registration and help display. It also refines chunk and chest access control to support group ownership. Below are the most important changes:

### Group/Clan Support and Data Migration

* Added initialization and migration for `GroupService`, enabling legacy group (clan) data stored in `groups.properties` to be migrated into the plugin's database on startup. This ensures existing group data is preserved and accessible after upgrading. [[1]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9R129) [[2]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9R166-R168)
* Enhanced the legacy data migration process to copy and detect `groups.properties` from previous and older world data directories, ensuring group data is not lost during upgrades. [[1]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9R239-R242) [[2]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9R253-R265) [[3]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9R282-R283)

### Command System Improvements

* Added a new `/clan` command category with comprehensive help entries for group management actions (create, info, invite, accept, leave, kick, promote, demote, claim, unclaim, disband).
* Refactored command registration to support additional help rows, and updated the UI to display all help entries for commands, improving user guidance and discoverability.

### Access Control Enhancements

* Updated chunk and chest access checks to use a new `canAccessOwner` method, which will allow for group-based ownership and permissions in addition to individual ownership. [[1]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9L553-R576) [[2]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9L704-R727) [[3]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9L1032-R1071)

### Miscellaneous

* Updated the plugin version to 0.8.3 in both `plugin.yml` and the in-game about window. [[1]](diffhunk://#diff-156fb0101e0f98ca5d55392ec94362e96b8c633dd5bded92e17fe96dc08cd476L3-R3) [[2]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9L930-R969)
* Minor fixes to command parsing and help filtering for better consistency and maintainability. [[1]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9L758-R781) [[2]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9R828-R857)

These changes lay the groundwork for robust group (clan) support, improve migration reliability, and enhance the user experience with better command documentation and access control.