### PR TITLE
Added Non UI unit testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ replay_pid*
 .gradle-user/
 build/
 build-verify/
+build-coverage/
 
 # Machine-specific editor configuration
 .vscode/

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ import groovy.json.JsonSlurper
 
 plugins {
     id 'java'
+    id 'jacoco'
 }
 
 repositories {
@@ -70,6 +71,22 @@ sourceSets {
         resources.srcDirs = ['.', 'src']
         resources.include 'resources/**', 'com/example/risingworldstarter/database/schema.sql'
     }
+    coreTest {
+        java.srcDirs = ['src', 'src/test/java']
+        java.include 'com/example/risingworldstarter/database/**'
+        java.include 'com/example/risingworldstarter/economy/**'
+        java.include 'com/example/risingworldstarter/groups/**'
+        java.include 'com/example/risingworldstarter/journal/**'
+        java.include 'com/example/risingworldstarter/userstore/**'
+        java.include 'com/example/risingworldstarter/tests/**'
+        resources.srcDirs = ['src']
+        resources.include 'com/example/risingworldstarter/database/schema.sql'
+    }
+}
+
+configurations {
+    coreTestImplementation.extendsFrom implementation
+    coreTestRuntimeOnly.extendsFrom runtimeOnly
 }
 
 dependencies {
@@ -79,6 +96,10 @@ dependencies {
     implementation 'org.xerial:sqlite-jdbc:3.53.1.0'
     implementation 'org.slf4j:slf4j-api:2.0.17'
     runtimeOnly 'org.slf4j:slf4j-nop:2.0.17'
+    coreTestImplementation 'org.junit.jupiter:junit-jupiter:5.14.1'
+    coreTestImplementation 'org.mockito:mockito-junit-jupiter:5.21.0'
+    coreTestRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.14.1'
+    coreTestRuntimeOnly 'org.slf4j:slf4j-nop:2.0.17'
 }
 
 java {
@@ -86,14 +107,73 @@ java {
     targetCompatibility = JavaVersion.VERSION_20
 }
 
+jacoco {
+    toolVersion = '0.8.15'
+}
+
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
     options.release = 20
     doFirst {
-        if (sdkJar == null) {
+        if (name == 'compileJava' && sdkJar == null) {
             throw new GradleException('Rising World Plugin API not found. Set -PrisingWorldPath="/path/to/RisingWorld", set RISING_WORLD_PATH, or update config/build.config.json for this computer.')
         }
     }
+}
+
+tasks.named('test', Test) {
+    description = 'Runs non-UI unit and SQLite repository tests.'
+    setDependsOn([tasks.named('coreTestClasses')])
+    testClassesDirs = sourceSets.coreTest.output.classesDirs
+    classpath = sourceSets.coreTest.runtimeClasspath
+    useJUnitPlatform()
+    testLogging {
+        events 'passed', 'skipped', 'failed'
+        exceptionFormat = 'full'
+    }
+}
+
+tasks.named('test') {
+    jacoco {
+        destinationFile = layout.buildDirectory.file('jacoco/test.exec').get().asFile
+    }
+    finalizedBy tasks.named('jacocoTestReport')
+}
+
+tasks.named('jacocoTestReport', JacocoReport) {
+    dependsOn tasks.named('test')
+    executionData(layout.buildDirectory.file('jacoco/test.exec'))
+    sourceDirectories.setFrom(files('src'))
+    classDirectories.setFrom(sourceSets.coreTest.output.classesDirs.asFileTree.matching {
+        exclude 'com/example/risingworldstarter/tests/**'
+    })
+    reports {
+        html.required = true
+        xml.required = true
+        csv.required = false
+    }
+}
+
+tasks.named('jacocoTestCoverageVerification', JacocoCoverageVerification) {
+    dependsOn tasks.named('test')
+    executionData(layout.buildDirectory.file('jacoco/test.exec'))
+    sourceDirectories.setFrom(files('src'))
+    classDirectories.setFrom(sourceSets.coreTest.output.classesDirs.asFileTree.matching {
+        exclude 'com/example/risingworldstarter/tests/**'
+    })
+    violationRules {
+        rule {
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.90
+            }
+        }
+    }
+}
+
+tasks.named('check') {
+    dependsOn tasks.named('jacocoTestReport'), tasks.named('jacocoTestCoverageVerification')
 }
 
 tasks.named('jar') {

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -1,0 +1,16 @@
+# Tests
+
+Run the non-UI suite with:
+
+```text
+./gradlew test
+```
+
+The suite uses JUnit 5, Mockito for dependency-isolation tests, and temporary
+SQLite databases for persistence and transaction behavior. `test` compiles
+only the database-backed modules, allowing backend tests to run independently
+from Rising World's UI and game-event API.
+
+JaCoCo runs with the test task and writes HTML and XML coverage reports under
+`build/reports/jacoco/test/`. When `alternateBuildDir` is used, replace `build`
+with that directory.

--- a/src/test/java/com/example/risingworldstarter/tests/EconomyServiceTest.java
+++ b/src/test/java/com/example/risingworldstarter/tests/EconomyServiceTest.java
@@ -1,0 +1,45 @@
+package com.example.risingworldstarter.tests;
+
+import com.example.risingworldstarter.economy.DatabaseEconomyService;
+import org.junit.jupiter.api.Test;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+final class EconomyServiceTest extends SqliteTestSupport {
+    @Test void depositsAndWithdrawalsPersist() {
+        var economy = new DatabaseEconomyService(database);
+        assertEquals(1_000L, economy.createAccount("character", 1_000L));
+        assertEquals(1_250L, economy.deposit("character", 250L));
+        assertTrue(economy.withdraw("character", 400L));
+        assertFalse(economy.withdraw("character", 1_000L));
+        assertEquals(850L, economy.getBalance("character"));
+    }
+
+    @Test void rejectsInvalidAmounts() {
+        var economy = new DatabaseEconomyService(database);
+        assertThrows(IllegalArgumentException.class, () -> economy.deposit("character", 0));
+        assertThrows(IllegalArgumentException.class, () -> economy.setBalance("character", -1));
+    }
+
+    @Test void supportsAccountLifecycleAndLegacyMigration() throws Exception {
+        var legacy = temporaryDirectory.resolve("balances.properties");
+        Files.writeString(legacy, "one=1200\ninvalid=nope\nnegative=-50\n");
+        var economy = new DatabaseEconomyService(database);
+        economy.migrateLegacy(legacy);
+        assertTrue(economy.hasAccount("one"));
+        assertEquals(1_200L, economy.getBalance("one"));
+        assertEquals(0L, economy.getBalance("negative"));
+        assertEquals(900L, economy.setBalance("one", 900L));
+        assertTrue(economy.deleteAccount("one"));
+        assertFalse(economy.deleteAccount("one"));
+        economy.migrateLegacy(temporaryDirectory.resolve("missing.properties"));
+    }
+
+    @Test void rejectsBlankAccountsAndOverflow() {
+        var economy = new DatabaseEconomyService(database);
+        assertThrows(IllegalArgumentException.class, () -> economy.getBalance(" "));
+        economy.createAccount("rich", Long.MAX_VALUE);
+        assertThrows(ArithmeticException.class, () -> economy.deposit("rich", 1));
+    }
+}

--- a/src/test/java/com/example/risingworldstarter/tests/EconomySettingsTest.java
+++ b/src/test/java/com/example/risingworldstarter/tests/EconomySettingsTest.java
@@ -1,0 +1,36 @@
+package com.example.risingworldstarter.tests;
+
+import com.example.risingworldstarter.economy.EconomySettings;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+final class EconomySettingsTest {
+    @TempDir Path directory;
+
+    @Test void createsDefaultsAndLoadsConfiguredAmounts() throws Exception {
+        Path file = directory.resolve("economy.properties");
+        EconomySettings defaults = EconomySettings.load(file);
+        assertTrue(Files.isRegularFile(file));
+        assertTrue(defaults.defaultBalance() > 0);
+        Files.writeString(file, "default-balance=12.34\nclaim-cost=5.00\nbase-salary=1.25\n");
+        EconomySettings configured = EconomySettings.load(file);
+        assertEquals(1_234L, configured.defaultBalance());
+        assertEquals(500L, configured.claimCost());
+        assertEquals(125L, configured.baseSalary());
+    }
+
+    @Test void rejectsNegativeMalformedAndOverPreciseValues() throws Exception {
+        Path file = directory.resolve("economy.properties");
+        Files.writeString(file, "default-balance=-1\nclaim-cost=5\nbase-salary=1\n");
+        assertThrows(IllegalArgumentException.class, () -> EconomySettings.load(file));
+        Files.writeString(file, "default-balance=1.001\nclaim-cost=5\nbase-salary=1\n");
+        assertThrows(IllegalArgumentException.class, () -> EconomySettings.load(file));
+        Files.writeString(file, "default-balance=abc\nclaim-cost=5\nbase-salary=1\n");
+        assertThrows(IllegalArgumentException.class, () -> EconomySettings.load(file));
+    }
+}

--- a/src/test/java/com/example/risingworldstarter/tests/GroupServiceTest.java
+++ b/src/test/java/com/example/risingworldstarter/tests/GroupServiceTest.java
@@ -1,0 +1,101 @@
+package com.example.risingworldstarter.tests;
+
+import com.example.risingworldstarter.economy.DatabaseEconomyService;
+import com.example.risingworldstarter.groups.GroupRole;
+import com.example.risingworldstarter.groups.GroupService;
+import org.junit.jupiter.api.Test;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+final class GroupServiceTest extends SqliteTestSupport {
+    @Test void creatorIsPersistedAsOwnerAndManagerCanUseTreasury() {
+        var economy = new DatabaseEconomyService(database);
+        var groups = new GroupService(database);
+        economy.createAccount("owner", 5_000L);
+        var clan = groups.create("Builders", "owner", "Owner");
+        assertEquals(GroupRole.OWNER, groups.findByMember("owner").orElseThrow()
+                .members().get("owner").role());
+        groups.invite(clan.id(), "owner", "manager");
+        groups.acceptInvitation("manager", "Manager");
+        groups.setManager(clan.id(), "owner", "manager", true);
+        assertEquals(1_500L, groups.deposit(clan.id(), "owner", 1_500L));
+        assertEquals(1_000L, groups.withdraw(clan.id(), "manager", 500L));
+        assertEquals(500L, economy.getBalance("manager"));
+    }
+
+    @Test void ordinaryMemberCannotViewTreasury() {
+        var groups = new GroupService(database);
+        var clan = groups.create("Builders", "owner", "Owner");
+        groups.invite(clan.id(), "owner", "member");
+        groups.acceptInvitation("member", "Member");
+        assertThrows(IllegalStateException.class, () -> groups.getBalance(clan.id(), "member"));
+    }
+
+    @Test void enforcesMembershipAndManagementRules() {
+        var groups = new GroupService(database);
+        var first = groups.create("Builders", "owner", "Owner");
+        assertThrows(IllegalStateException.class, () -> groups.create("builders", "other", "Other"));
+        assertThrows(IllegalStateException.class, () -> groups.create("Other", "owner", "Owner"));
+        groups.invite(first.id(), "owner", "manager");
+        groups.acceptInvitation("manager", "Manager");
+        groups.setManager(first.id(), "owner", "manager", true);
+        groups.invite(first.id(), "manager", "member");
+        groups.acceptInvitation("member", "Member");
+        assertTrue(groups.canAccess("member", first.claimOwnerId()));
+        assertFalse(groups.canAccess("unknown", first.claimOwnerId()));
+        assertFalse(groups.canAccess("member", "personal"));
+        assertThrows(IllegalStateException.class, () -> groups.kick(first.id(), "member", "manager"));
+        assertThrows(IllegalStateException.class, () -> groups.kick(first.id(), "manager", "manager"));
+        groups.kick(first.id(), "owner", "manager");
+        groups.leave("member");
+        assertTrue(groups.findByMember("member").isEmpty());
+        assertThrows(IllegalStateException.class, () -> groups.leave("owner"));
+        assertEquals(1, groups.getGroups().size());
+    }
+
+    @Test void protectsFundedClanAndDisbandsEmptyClan() {
+        var groups = new GroupService(database);
+        var economy = new DatabaseEconomyService(database);
+        economy.createAccount("owner", 1_000L);
+        var clan = groups.create("Builders", "owner", "Owner");
+        groups.deposit(clan.id(), "owner", 500L);
+        assertThrows(IllegalStateException.class, () -> groups.disband(clan.id(), "owner"));
+        groups.withdraw(clan.id(), "owner", 500L);
+        assertEquals(clan.id(), groups.disband(clan.id(), "owner").id());
+        assertTrue(groups.get(clan.id()).isEmpty());
+    }
+
+    @Test void removesDeletedMembersAndMigratesLegacyFileOnce() throws Exception {
+        var groups = new GroupService(database);
+        var clan = groups.create("Current", "owner", "Owner");
+        groups.invite(clan.id(), "owner", "member"); groups.acceptInvitation("member", "Member");
+        groups.removeDeletedCharacter("member");
+        assertTrue(groups.findByMember("member").isEmpty());
+        assertThrows(IllegalStateException.class, () -> groups.removeDeletedCharacter("owner"));
+
+        String id="legacy"; String key="legacy-character";
+        String encodedName=Base64.getUrlEncoder().withoutPadding().encodeToString("Legacy Clan".getBytes(StandardCharsets.UTF_8));
+        String encodedKey=Base64.getUrlEncoder().withoutPadding().encodeToString(key.getBytes(StandardCharsets.UTF_8));
+        String encodedMember=Base64.getUrlEncoder().withoutPadding().encodeToString("Legacy Owner".getBytes(StandardCharsets.UTF_8));
+        var file=temporaryDirectory.resolve("groups.properties");
+        Files.writeString(file,"group."+id+".name="+encodedName+"\n"
+                +"group."+id+".member."+encodedKey+"=OWNER:"+encodedMember+"\n");
+        groups.migrateLegacy(file); groups.migrateLegacy(file);
+        assertEquals("Legacy Clan", groups.findByMember(key).orElseThrow().name());
+    }
+
+    @Test void validatesNamesInvitationsAndRoles() {
+        var groups=new GroupService(database); var clan=groups.create("Builders","owner","Owner");
+        assertThrows(IllegalArgumentException.class,()->groups.create(" ","x","X"));
+        assertThrows(IllegalArgumentException.class,()->groups.create("x".repeat(33),"x","X"));
+        assertThrows(IllegalStateException.class,()->groups.acceptInvitation("none","None"));
+        groups.invite(clan.id(),"owner","member"); groups.acceptInvitation("member","Member");
+        assertThrows(IllegalStateException.class,()->groups.invite(clan.id(),"owner","member"));
+        assertThrows(IllegalStateException.class,()->groups.setManager(clan.id(),"member","owner",true));
+        assertThrows(IllegalStateException.class,()->groups.setManager(clan.id(),"owner","owner",true));
+        assertThrows(IllegalStateException.class,()->groups.disband(clan.id(),"member"));
+    }
+}

--- a/src/test/java/com/example/risingworldstarter/tests/JournalServiceTest.java
+++ b/src/test/java/com/example/risingworldstarter/tests/JournalServiceTest.java
@@ -1,0 +1,46 @@
+package com.example.risingworldstarter.tests;
+
+import com.example.risingworldstarter.journal.JournalService;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+final class JournalServiceTest extends SqliteTestSupport {
+    @Test void sectionsAndOrderedPagesAreCharacterScoped() {
+        var journals = new JournalService(database);
+        var section = journals.createSection("one", "Plans");
+        var first = journals.getPages("one", section.id()).get(0);
+        journals.savePage("one", first.id(), "First page");
+        var second = journals.createPage("one", section.id());
+        journals.savePage("one", second.id(), "Second page");
+        var pages = journals.getPages("one", section.id());
+        assertAll(() -> assertEquals(2, pages.size()),
+                () -> assertEquals(1, pages.get(0).pageNumber()),
+                () -> assertEquals("Second page", pages.get(1).content()));
+        assertThrows(IllegalStateException.class, () -> journals.getPages("two", section.id()));
+    }
+
+    @Test void opensDefaultsAndDeletesWholeJournal() {
+        var journals=new JournalService(database);
+        var sections=journals.open("character");
+        assertEquals("Notes",sections.get(0).title());
+        journals.createSection("character","Ideas");
+        assertEquals(2,journals.getSections("character").size());
+        assertEquals(2,journals.deleteJournal("character"));
+        assertTrue(journals.getSections("character").isEmpty());
+    }
+
+    @Test void validatesTitlesContentAndOwnership() {
+        var journals=new JournalService(database);
+        assertThrows(IllegalArgumentException.class,()->journals.open(" "));
+        assertThrows(IllegalArgumentException.class,()->journals.createSection("character"," "));
+        assertThrows(IllegalArgumentException.class,()->journals.createSection("character","x".repeat(49)));
+        var section=journals.createSection("character","Notes");
+        var page=journals.getPages("character",section.id()).get(0);
+        assertThrows(IllegalArgumentException.class,()->journals.savePage("character",page.id(),"x".repeat(8_001)));
+        assertThrows(IllegalStateException.class,()->journals.savePage("other",page.id(),"no"));
+        assertThrows(IllegalStateException.class,()->journals.createPage("other",section.id()));
+        journals.savePage("character",page.id(),null);
+        assertEquals("",journals.getPages("character",section.id()).get(0).content());
+    }
+}

--- a/src/test/java/com/example/risingworldstarter/tests/SqliteDatabaseTest.java
+++ b/src/test/java/com/example/risingworldstarter/tests/SqliteDatabaseTest.java
@@ -1,0 +1,27 @@
+package com.example.risingworldstarter.tests;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+final class SqliteDatabaseTest extends SqliteTestSupport {
+    @Test void transactionRollsBackSqlAndRuntimeFailures() {
+        assertThrows(IllegalStateException.class,()->database.transaction(connection->{
+            try(PreparedStatement insert=connection.prepareStatement("INSERT INTO balances(account_id,balance) VALUES('one',10)")){insert.executeUpdate();}
+            throw new IllegalStateException("rollback");
+        }));
+        long balanceCount=database.read(connection->{try(var query=connection.prepareStatement("SELECT COUNT(*) FROM balances");var row=query.executeQuery()){return row.getLong(1);}});
+        assertEquals(0L,balanceCount);
+        assertThrows(IllegalStateException.class,()->database.read(connection->{throw new SQLException("failure");}));
+    }
+
+    @Test void closeIsSafeAndSchemaIsIdempotent() {
+        database.close();
+        assertDoesNotThrow(database::close);
+        long metadataCount=database.read(connection->{try(var query=connection.prepareStatement("SELECT COUNT(*) FROM metadata");var row=query.executeQuery()){return row.getLong(1);}});
+        assertEquals(0L,metadataCount);
+    }
+}

--- a/src/test/java/com/example/risingworldstarter/tests/SqliteTestSupport.java
+++ b/src/test/java/com/example/risingworldstarter/tests/SqliteTestSupport.java
@@ -1,0 +1,21 @@
+package com.example.risingworldstarter.tests;
+
+import com.example.risingworldstarter.database.SqliteDatabase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+abstract class SqliteTestSupport {
+    @TempDir Path temporaryDirectory;
+    protected SqliteDatabase database;
+
+    @BeforeEach void openDatabase() {
+        database = new SqliteDatabase(temporaryDirectory.resolve("test.db"));
+    }
+
+    @AfterEach void closeDatabase() {
+        database.close();
+    }
+}

--- a/src/test/java/com/example/risingworldstarter/tests/UserStoreServiceTest.java
+++ b/src/test/java/com/example/risingworldstarter/tests/UserStoreServiceTest.java
@@ -1,0 +1,63 @@
+package com.example.risingworldstarter.tests;
+
+import com.example.risingworldstarter.economy.DatabaseEconomyService;
+import com.example.risingworldstarter.userstore.UserStoreService;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+final class UserStoreServiceTest extends SqliteTestSupport {
+    @Test void purchaseTransfersFundsAndConsumesListing() {
+        var economy = new DatabaseEconomyService(database);
+        var store = new UserStoreService(database);
+        economy.createAccount("seller", 100L); economy.createAccount("buyer", 2_000L);
+        var listing = store.create("seller", "Seller", (short) 7, 0, 3, 1_250L);
+        var purchased = store.purchase(listing.id(), "buyer");
+        assertAll(() -> assertEquals(3, purchased.quantity()),
+                () -> assertEquals(750L, economy.getBalance("buyer")),
+                () -> assertEquals(1_350L, economy.getBalance("seller")),
+                () -> assertTrue(store.getListings().isEmpty()));
+    }
+
+    @Test void reversalRestoresFundsAndListing() {
+        var economy = new DatabaseEconomyService(database);
+        var store = new UserStoreService(database);
+        economy.createAccount("seller", 0L); economy.createAccount("buyer", 2_000L);
+        var purchased = store.purchase(store.create("seller", "Seller", (short) 7, 0, 1, 500L).id(), "buyer");
+        store.reversePurchase(purchased, "buyer");
+        assertEquals(2_000L, economy.getBalance("buyer"));
+        assertEquals(0L, economy.getBalance("seller"));
+        assertEquals(1, store.getListings().size());
+    }
+
+    @Test void exposesStockAndSupportsSellerCancellation() {
+        var store=new UserStoreService(database);
+        var listing=store.create("seller","Seller",(short)7,2,4,500L);
+        assertTrue(store.hasListings("seller"));
+        assertFalse(store.hasListings("other"));
+        assertTrue(store.getListedItemTypes().contains((short)7));
+        assertThrows(IllegalStateException.class,()->store.cancel(listing.id(),"other"));
+        assertEquals(listing,store.cancel(listing.id(),"seller").orElseThrow());
+        assertTrue(store.cancel(listing.id(),"seller").isEmpty());
+    }
+
+    @Test void rejectsInvalidOrUnauthorizedPurchases() {
+        var economy=new DatabaseEconomyService(database);var store=new UserStoreService(database);
+        economy.createAccount("buyer",100L);
+        assertThrows(IllegalArgumentException.class,()->store.create("seller","Seller",(short)1,0,0,100));
+        assertThrows(IllegalArgumentException.class,()->store.create("seller","Seller",(short)1,0,1,0));
+        var listing=store.create("seller","Seller",(short)1,0,1,500L);
+        assertThrows(IllegalStateException.class,()->store.purchase(listing.id(),"seller"));
+        assertThrows(IllegalStateException.class,()->store.purchase(listing.id(),"buyer"));
+        assertThrows(IllegalStateException.class,()->store.purchase(999,"buyer"));
+        assertEquals(1,store.getListings().size());
+    }
+
+    @Test void reversalFailsWhenSellerFundsAreGone() {
+        var economy=new DatabaseEconomyService(database);var store=new UserStoreService(database);
+        economy.createAccount("buyer",1_000L);economy.createAccount("seller",0L);
+        var purchased=store.purchase(store.create("seller","Seller",(short)1,0,1,500L).id(),"buyer");
+        economy.setBalance("seller",0L);
+        assertThrows(IllegalStateException.class,()->store.reversePurchase(purchased,"buyer"));
+    }
+}

--- a/src/test/java/com/example/risingworldstarter/tests/ValidationMockTest.java
+++ b/src/test/java/com/example/risingworldstarter/tests/ValidationMockTest.java
@@ -1,0 +1,29 @@
+package com.example.risingworldstarter.tests;
+
+import com.example.risingworldstarter.database.Database;
+import com.example.risingworldstarter.groups.GroupService;
+import com.example.risingworldstarter.journal.JournalService;
+import com.example.risingworldstarter.userstore.UserStoreService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+final class ValidationMockTest {
+    @Mock Database database;
+
+    @Test void invalidInputIsRejectedBeforePersistence() {
+        var groups = new GroupService(database);
+        var journals = new JournalService(database);
+        var userStore = new UserStoreService(database);
+        assertThrows(IllegalArgumentException.class, () -> groups.deposit("group", "actor", 0));
+        assertThrows(IllegalArgumentException.class, () -> journals.open(" "));
+        assertThrows(IllegalArgumentException.class,
+                () -> userStore.create("seller", "Seller", (short) 1, 0, 0, 100));
+        verifyNoInteractions(database);
+    }
+}


### PR DESCRIPTION
This pull request introduces a comprehensive suite of backend unit tests for the project, covering core services such as economy, groups, journals, user stores, and database transactions. The tests use JUnit 5, Mockito for mocking, and temporary SQLite databases to ensure isolation and persistence validation. Additionally, the PR adds test infrastructure and documentation for running and understanding the test suite.

**Test suite and infrastructure additions:**

* Added a `README.md` in `src/test` with instructions for running tests, coverage reporting, and test dependencies.
* Introduced `SqliteTestSupport`, a reusable base class that manages temporary SQLite databases for test isolation.

**Service and feature test coverage:**

* Economy: Added `EconomyServiceTest` and `EconomySettingsTest` to verify account lifecycle, persistence, input validation, and settings file parsing. [[1]](diffhunk://#diff-6be4e397ad5d915174666a946f4b78268f7d188c412036c9dca0d7f5f8b4afc7R1-R45) [[2]](diffhunk://#diff-ed00d9372e891e6a9c196cbf3ebe3e39a454e9ae3b2e035ccb28d8d0ffa208b5R1-R36)
* Groups: Added `GroupServiceTest` to validate group creation, membership, treasury access, legacy migration, and rules enforcement.
* Journals: Added `JournalServiceTest` to cover section/page management, content validation, and ownership rules.
* User Store: Added `UserStoreServiceTest` to test listing creation, purchases, reversals, stock management, and invalid operations.

**Database and validation testing:**

* Database: Added `SqliteDatabaseTest` to ensure transactionality, rollback behavior, and schema idempotency.
* Validation: Added `ValidationMockTest` using Mockito to confirm that invalid inputs are rejected before database interaction.