### PR TITLE
Changed the clan claim color to purple

### DIFF
--- a/src/com/example/risingworldstarter/CivicCore.java
+++ b/src/com/example/risingworldstarter/CivicCore.java
@@ -1519,8 +1519,8 @@ public final class CivicCore extends Plugin implements Listener {
                             0.30f, 0.65f, 1.0f, 0.95f);
                 } else if (claim.ownerUid().equals(clanOwnerId)) {
                     visual = createChunkVisual(chunkX, chunkZ, groundY,
-                            1.0f, 0.50f, 0.08f, 0.12f,
-                            1.0f, 0.65f, 0.18f, 0.95f);
+                            0.62f, 0.25f, 0.90f, 0.12f,
+                            0.78f, 0.45f, 1.0f, 0.95f);
                 } else {
                     visual = createChunkVisual(chunkX, chunkZ, groundY,
                             1.0f, 0.15f, 0.15f, 0.12f,
@@ -1534,7 +1534,7 @@ public final class CivicCore extends Plugin implements Listener {
         visualModes.put(player.getUID(), "claims");
         visualHeights.put(player.getUID(), groundY);
         player.sendTextMessage("<color=#77AAFF>Blue: yours</color> | <color=#77FF77>Green: available</color>"
-                + " | <color=#FF991F>Orange: your clan</color> | <color=#FF5555>Red: unavailable</color>");
+                + " | <color=#C774FF>Purple: your clan</color> | <color=#FF5555>Red: unavailable</color>");
         player.sendTextMessage("<color=#AAAAAA>Showing a " + sideLength + "x" + sideLength
                 + " chunk area around you. Use /claims again to hide it.</color>");
     }

--- a/src/com/example/risingworldstarter/claims/README.md
+++ b/src/com/example/risingworldstarter/claims/README.md
@@ -27,7 +27,7 @@ database. Other plugins can access claims through `CivicCore.getClaimService()`.
 - `/claimadmin list` lists claim administrators.
 
 In the `/claims` overview, boundaries are green when available, blue when owned
-by the viewing character, orange when owned by that character's clan, and red
+by the viewing character, purple when owned by that character's clan, and red
 when unavailable. The overview uses one bounded database query when opened.
 
 ## Protection rules


### PR DESCRIPTION
This pull request updates the color scheme for clan-owned chunks in the `/claims` overview to improve clarity and consistency. The main changes include updating the visual colors for clan-owned chunks from orange to purple, and reflecting this change in both user-facing messages and documentation.

**Visual and UI Updates:**

* Changed the highlight color for clan-owned chunks in `listOwnedChunks` from orange to purple by updating the RGBA values passed to `createChunkVisual`.
* Updated the legend message sent to players to describe clan-owned chunks as purple instead of orange.

**Documentation:**

* Updated the `/claims` overview section in `README.md` to state that clan-owned chunks are purple, not orange.