### PR TITLE
Changed /claims to 11x11

### DIFF
--- a/src/com/example/risingworldstarter/CivicCore.java
+++ b/src/com/example/risingworldstarter/CivicCore.java
@@ -93,7 +93,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Minimal entry point for a Rising World (Unity version) plugin.
  */
 public final class CivicCore extends Plugin implements Listener {
-    private static final int CLAIM_OVERVIEW_RADIUS = 10;
+    private static final int CLAIM_OVERVIEW_RADIUS = 5;
     private static final int[] SKIN_COLORS = {
             0xF1C27D, 0xE0AC69, 0xC68642, 0xA66A3F, 0x8D5524, 0x5C3317
     };

--- a/src/com/example/risingworldstarter/claims/README.md
+++ b/src/com/example/risingworldstarter/claims/README.md
@@ -19,7 +19,7 @@ database. Other plugins can access claims through `CivicCore.getClaimService()`.
 
 - `/claim` claims the current chunk.
 - `/chunk` reports and visualizes the current chunk and owner.
-- `/claims` lists personal claims and toggles a 21-by-21 chunk ownership overview
+- `/claims` lists personal claims and toggles an 11-by-11 chunk ownership overview
   centered on the active character's current chunk.
 - `/unclaim` releases the current chunk.
 - `/claimadmin add <online-player>` adds a claim administrator.


### PR DESCRIPTION
This pull request makes a small adjustment to the claim overview feature, reducing its radius from 10 to 5. As a result, the `/claims` command now displays an 11-by-11 chunk ownership overview instead of 21-by-21. The main changes are:

Claim overview radius adjustment:

* Reduced the `CLAIM_OVERVIEW_RADIUS` constant in `CivicCore.java` from 10 to 5, which changes the size of the area visualized around the player.
* Updated the `/claims` command documentation in `claims/README.md` to reflect the new 11-by-11 chunk overview.