### PR TITLE
Made it easier to see you aren't allowed.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ def sdkJar = findSdkJar(risingWorldDirectory)
 sourceSets {
     main {
         java.srcDirs = ['src']
+        java.exclude 'test/**'
         resources.srcDirs = ['.', 'src']
         resources.include 'resources/**', 'com/example/risingworldstarter/database/schema.sql'
     }

--- a/src/com/example/risingworldstarter/CivicCore.java
+++ b/src/com/example/risingworldstarter/CivicCore.java
@@ -594,7 +594,7 @@ public final class CivicCore extends Plugin implements Listener {
         // Opening a storage is governed by its own lock. Other object state
         // changes (doors, lights, etc.) remain covered by chunk protection.
         if (!isStorage(event.getObjectDefinition())) {
-            protect(event, event.getChunkPositionX(), event.getChunkPositionZ());
+            protectInteraction(event, event.getChunkPositionX(), event.getChunkPositionZ());
         }
     }
 
@@ -716,7 +716,7 @@ public final class CivicCore extends Plugin implements Listener {
     }
 
     private void protectOwnedLand(Cancellable event, int chunkX, int chunkZ) {
-        protect(event, chunkX, chunkZ, true);
+        protect(event, chunkX, chunkZ, true, false);
     }
 
     private void refundConsumedItemAfterPlacement(Player player, short typeId, int variant) {
@@ -736,10 +736,15 @@ public final class CivicCore extends Plugin implements Listener {
     }
 
     private void protect(Cancellable event, int chunkX, int chunkZ) {
-        protect(event, chunkX, chunkZ, false);
+        protect(event, chunkX, chunkZ, false, false);
     }
 
-    private void protect(Cancellable event, int chunkX, int chunkZ, boolean requiresOwnedLand) {
+    private void protectInteraction(Cancellable event, int chunkX, int chunkZ) {
+        protect(event, chunkX, chunkZ, false, true);
+    }
+
+    private void protect(Cancellable event, int chunkX, int chunkZ, boolean requiresOwnedLand,
+                         boolean alwaysNotify) {
         if (event.isCancelled()) return;
         Player player = ((net.risingworld.api.events.player.PlayerEvent) event).getPlayer();
         Claim claim = claims.getClaim(chunkX, chunkZ).orElse(null);
@@ -751,7 +756,7 @@ public final class CivicCore extends Plugin implements Listener {
             sendClaimProtectionNotice(player,
                     "Claim chunk " + chunkX + ", " + chunkZ
                             + " before placing items or modifying terrain. ["
-                            + event.getClass().getSimpleName() + "]");
+                            + event.getClass().getSimpleName() + "]", alwaysNotify);
             return;
         }
         String activeClaimIdentity = activeClaimIdentity(player);
@@ -762,10 +767,19 @@ public final class CivicCore extends Plugin implements Listener {
         debug("Denied " + event.getClass().getSimpleName() + " for " + player.getName()
                 + " in chunk " + chunkX + "," + chunkZ + ": active claim identity="
                 + activeClaimIdentity + ", owner=" + claim.ownerUid());
-        sendClaimProtectionNotice(player, "This chunk is protected by " + claim.ownerName() + ".");
+        sendClaimProtectionNotice(player, "This chunk is protected by " + claim.ownerName() + ".",
+                alwaysNotify);
     }
 
     private void sendClaimProtectionNotice(Player player, String message) {
+        sendClaimProtectionNotice(player, message, false);
+    }
+
+    private void sendClaimProtectionNotice(Player player, String message, boolean alwaysNotify) {
+        if (alwaysNotify) {
+            player.sendTextMessage("<color=#FF7777>" + message + "</color>");
+            return;
+        }
         long now = System.currentTimeMillis();
         Long previous = claimProtectionNotices.put(player.getUID(), now);
         if (previous == null || now - previous >= 1500L) {


### PR DESCRIPTION
This pull request refactors the claim protection logic in `CivicCore.java` to provide more granular control over player notifications and to clarify the distinction between general protection and interaction-specific protection. The main changes include introducing an `alwaysNotify` flag to the protection and notification methods, splitting the protection logic into `protect` and `protectInteraction`, and updating the relevant method calls to use these new signatures.

**Claim protection logic improvements:**

* Added an `alwaysNotify` parameter to the `protect` and `sendClaimProtectionNotice` methods to allow certain interactions to always notify the player, bypassing the notification rate limit. [[1]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9L739-R747) [[2]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9L765-R782)
* Split protection logic into `protect` (for general protection) and `protectInteraction` (for interaction-specific protection), with corresponding method updates and refactoring of calls (e.g., from `protect` to `protectInteraction` in `onPlayerChangeEquippedItem`). [[1]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9L597-R597) [[2]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9L739-R747)
* Updated `protectOwnedLand` and related internal calls to use the new method signatures with the `alwaysNotify` flag, improving clarity and intent. [[1]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9L719-R719) [[2]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9L739-R747)

**Player notification handling:**

* Modified `sendClaimProtectionNotice` to accept the `alwaysNotify` flag; when set, the player is always notified immediately, otherwise the existing rate-limiting logic is used.
* Updated all calls to `sendClaimProtectionNotice` within the protection logic to pass the appropriate `alwaysNotify` value. [[1]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9L754-R759) [[2]](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9L765-R782)