### PR TITLE
Added Basic Background To UI

### DIFF
--- a/src/com/example/risingworldstarter/CivicCore.java
+++ b/src/com/example/risingworldstarter/CivicCore.java
@@ -3173,9 +3173,9 @@ public final class CivicCore extends Plugin implements Listener {
         label.setTextAlign(TextAnchor.MiddleCenter);
         label.setFontSize(22f);
         label.setFontColor((int) 0xF4E3A1FFL);
-        //label.setBackgroundColor((int) 0x161B22CCL);
-        //label.setBorder(2f);
-        //label.setBorderColor((int) 0xE8C547FFL);
+        label.setBackgroundColor((int) 0x161B22D9L);
+        label.setBorder(2f);
+        label.setBorderColor((int) 0xE8C547FFL);
         label.setPosition(12f, 12f, false);
         label.setPivot(Pivot.UpperLeft);
         label.setSize(260f, 42f, false);
@@ -3195,6 +3195,9 @@ public final class CivicCore extends Plugin implements Listener {
         label.setTextAlign(TextAnchor.MiddleCenter);
         label.setFontSize(20f);
         label.setFontColor((int) 0xF4E3A1FFL);
+        label.setBackgroundColor((int) 0x161B22D9L);
+        label.setBorder(2f);
+        label.setBorderColor((int) 0xE8C547FFL);
         label.setPosition(50f, 0.5f, true);
         label.setPivot(Pivot.UpperCenter);
         label.setSize(460f, 42f, false);


### PR DESCRIPTION
This pull request updates the UI styling for the balance and world clock labels in `CivicCore.java` to improve visual consistency and clarity. The main changes involve setting background color, border, and border color properties for these labels.

**UI improvements:**

* [`showBalance(Player player)`](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9L3176-R3178): Enabled and updated the label's background color, border, and border color for better visibility.
* [`showWorldClock(Player player)`](diffhunk://#diff-469a0383b60f2f13672aa971c9260c51bb26ce8129cdc9c7653888aad6003ad9R3198-R3200): Added background color, border, and border color to the label to match the updated balance label styling.