### PR TITLE
Added Ability To Sell Items to Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ the game's square item icon, its name and price, and quantity controls.
 Buying deducts the price and places one unit in the player's inventory. A failed
 inventory insertion is refunded. Items are sorted and grouped under the category
 reported by the game; definitions without a category appear under `Other`.
+Equip an item sold by the marketplace and use `/store sell [quantity]` to sell
+some or all of its stack back for 50% of its purchase price. Sold items are
+removed from the player's inventory and leave the game economy; the store does
+not retain stock. Items whose resale value rounds down to zero cannot be sold.
 Clickable category tabs, including an `All` tab, filter the product list. The
 search field performs a case-insensitive item-name search within the selected
 category as the player types.

--- a/src/com/example/risingworldstarter/CivicCore.java
+++ b/src/com/example/risingworldstarter/CivicCore.java
@@ -961,8 +961,9 @@ public final class CivicCore extends Plugin implements Listener {
                     player.sendTextMessage("<color=#E8C547>Cash:</color> " + formattedBalance);
                     updateBalanceLabel(player);
                 });
-        registerCommand("Marketplace", "/store", "Open or close the marketplace.", true, List.of(),
-                (player, parts) -> toggleStore(player));
+        registerCommand("Marketplace", "/store", "Open or close the marketplace.", true, List.of(), List.of(
+                new CommandHelp("/store sell [quantity]", "Sell the equipped item to the store.")),
+                this::handleStoreCommand);
         registerCommand("Marketplace", "/userstore", "Open the player marketplace.", true, List.of("/ustore"), List.of(
                 new CommandHelp("/userstore sell <price> [quantity]", "List the equipped item stack for sale.")),
                 this::handleUserStoreCommand);
@@ -3224,6 +3225,43 @@ public final class CivicCore extends Plugin implements Listener {
         }
     }
 
+    private void handleStoreCommand(Player player, String[] parts) {
+        if (parts.length == 1) { toggleStore(player); return; }
+        if (!parts[1].equalsIgnoreCase("sell") || parts.length > 3) {
+            player.sendTextMessage("Usage: /store or /store sell [quantity]"); return;
+        }
+        try {
+            Inventory inventory = player.getInventory();
+            int slot = inventory.getEquippedItemSlot();
+            Inventory.SlotType slotType = inventory.getEquippedItemSlotType();
+            Item equipped = inventory.getItem(slot, slotType);
+            if (equipped == null || !equipped.isValid()) throw new IllegalStateException("Equip the item you want to sell.");
+            StoreCatalog.StoreItem catalogItem = storeCatalog.find(equipped.getTypeID());
+            if (catalogItem == null) throw new IllegalStateException("The store does not buy that item.");
+            if (catalogItem.sellPrice() <= 0) throw new IllegalStateException("That item has no resale value.");
+            int quantity = parts.length == 3 ? Integer.parseInt(parts[2]) : equipped.getStack();
+            if (quantity <= 0 || quantity > equipped.getStack())
+                throw new IllegalArgumentException("Quantity must be between 1 and " + equipped.getStack() + ".");
+            long proceeds = Math.multiplyExact(catalogItem.sellPrice(), quantity);
+            short itemType = equipped.getTypeID(); int variant = equipped.getVariant();
+            if (!inventory.removeItem(slot, slotType, quantity))
+                throw new IllegalStateException("Could not remove the item from inventory.");
+            try {
+                economy.deposit(characterKey(player), proceeds);
+            } catch (RuntimeException exception) {
+                inventory.addItem(itemType, variant, quantity);
+                throw exception;
+            }
+            updateBalanceLabel(player);
+            player.sendTextMessage("<color=#77FF99>Sold " + quantity + " × " + catalogItem.name()
+                    + " for " + formatBalance(proceeds) + ".</color>");
+        } catch (NumberFormatException exception) {
+            player.sendTextMessage("<color=#FF7777>Quantity must be a whole number.</color>");
+        } catch (RuntimeException exception) {
+            player.sendTextMessage("<color=#FF7777>" + exception.getMessage() + "</color>");
+        }
+    }
+
     private void toggleUserStore(Player player) {
         if (userStoreViews.containsKey(player.getUID())) { closeUserStore(player); return; }
         if (storeViews.containsKey(player.getUID())) closeStore(player);
@@ -3483,7 +3521,7 @@ public final class CivicCore extends Plugin implements Listener {
             if (outOfStock) view.cart().remove(storeItem.id());
             UILabel itemDetails = new UILabel(storeItem.name() + "\n"
                     + (outOfStock ? "<color=#FF7777>OUT OF STOCK — available in User Store</color>"
-                    : formatBalance(storeItem.price())));
+                    : "Buy " + formatBalance(storeItem.price()) + "  •  Sell " + formatBalance(storeItem.sellPrice())));
             itemDetails.setPosition(98f, 7f, false);
             itemDetails.setSize(280f, 72f, false);
             itemDetails.setFontSize(18f);

--- a/src/com/example/risingworldstarter/StoreCatalog.java
+++ b/src/com/example/risingworldstarter/StoreCatalog.java
@@ -17,6 +17,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 final class StoreCatalog {
+    private static final int STORE_BUYBACK_PERCENT = 50;
     private static final Set<String> BLOCKED_ITEM_NAMES = Set.of(
             "clothingitem", "oldboot", "missingitem", "constructionitem",
             "objectkit", "objectkitsmall", "plantitem", "blueprint", "branch");
@@ -179,5 +180,8 @@ final class StoreCatalog {
     }
 
     record StoreItem(short id, String name, String category, long price) {
+        long sellPrice() {
+            return Math.multiplyExact(price, STORE_BUYBACK_PERCENT) / 100L;
+        }
     }
 }


### PR DESCRIPTION
This pull request adds a new feature allowing players to sell equipped items back to the store for 50% of their purchase price, along with related UI and backend changes. It also updates command registration and help documentation to reflect the new `/store sell [quantity]` command.

**Store Sell Feature:**

* Added a `/store sell [quantity]` command that lets players sell the equipped item back to the store for 50% of its purchase price. The command validates the item, quantity, and handles inventory and economy updates, including error handling and user feedback.
* Updated the store UI to display both buy and sell prices for each item, improving transparency for players.
* Implemented a `sellPrice()` method in the `StoreItem` record, calculating sell price as 50% of the buy price. [[1]](diffhunk://#diff-7fc70f51028f1a121ecb0e3bfea121733dd4eaced225d28e7944cea10b316787R20) [[2]](diffhunk://#diff-7fc70f51028f1a121ecb0e3bfea121733dd4eaced225d28e7944cea10b316787R183-R185)

**Command Registration and Documentation:**

* Updated the `/store` command registration to include help for the new `/store sell [quantity]` command, and routed command handling through a new handler method.
* Updated the `README.md` to document the new selling feature, including usage details and restrictions.